### PR TITLE
Recommend Contributor Covenant v2.0

### DIFF
--- a/project-submission-template.md
+++ b/project-submission-template.md
@@ -10,11 +10,11 @@
 4.  High level assessment of project synergy with existing projects under the CCC, including how the project compliments/overlaps with existing projects, and potential ways to harmonize over time. Responses may be included both inline and/or in accompanying documentation.
 5. Describe the [Trusted Computing Base (TCB)](https://en.wikipedia.org/wiki/Trusted_computing_base) of the project. If the project supports multiple environments please describe each TCB. Also identify if dependencies of other project (both CCC or non-CCC) TCBs are taken.
 6.  Project website URL
-7.  Project Code of Conduct URL
+7.  Project Code of Conduct URL.  We recommend a [Contributor Covenant v2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/) based Code of Conduct, so if the Code of Conduct is not based on that, explain why.
 8.  Source control URL
 9.  Issue tracker URL
 10. Project Logo URL or attachment (Vector Graphic: SVG, EPS)
-11. Project license
+11. Project license.  We recommend an [OSI-approved license](https://opensource.org/licenses), so if the license is not one on the list, explain why.
 12. External dependencies (including licenses)
 13. Standards implemented by the project, if any. Include links to any such standards.
 14. Release methodology and mechanics


### PR DESCRIPTION
On the March 5 TAC call, the TAC got tentative consensus to
“Recommend projects use Contributor Covenant v2.0 <https://www.contributor-covenant.org/version/2/0/code_of_conduct/> as a baseline, but if projects want to diverge, that would be allowed (and lightly discussed).” and https://github.com/confidential-computing/governance/blob/master/code-of-conduct.md already uses it for the TAC’s governance repo itself. 
