### PR TITLE
Update link in Code of Conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -39,9 +39,9 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at legal@confidentialcomputing.io. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the CCC Governing Board at conduct@confidentialcomputing.io.
 
-All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+All reports will be reviewed and investigated promptly and fairly. Community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
 


### PR DESCRIPTION
Update the email link for reporting code of conduct incidents, clarify who the recipients are, and replace the word "complaints" with "reports".

Closes issue #37