### PR TITLE
Add Governing Board meeting minutes

### DIFF
--- a/Board Meeting Minutes/CCC Board Minutes 2019-10-10.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2019-10-10.md
@@ -1,0 +1,108 @@
+**Confidential Computing Consortium**
+
+**Minutes of the Meeting of the Governing Board**
+
+**October 10, 2019**
+
+**Members of the Governing Board Participating in the Meeting:**
+
+-   Peixin Hou (Huawei)
+
+-   Philippe Robin (ARM)
+
+-   Gilad Golan (Google)
+
+-   Mike Uomoto (Intel)
+
+-   Stephen Walli (Microsoft)
+
+-   Wim Coekaerts (Oracle, joined at 10:42am)
+
+**Also Attending:**
+
+-   Jesse Schrater (Intel)
+
+-   Scott Nicholas (LF)
+
+-   Mike Dolan (LF)
+
+**Not in attendance:**
+
+-   Xiaoning Li (Alibaba)
+
+-   Mike Bursell (Red Hat)
+
+Scott conducted role call and opened the meeting at 10:04 am US Eastern
+Time. Stephen raised a question regarding responding to a request for a
+quote for another project being set up in a complementary space. Stephen
+notified the group he would ask for permission to send the materials.
+
+Scott reviewed the agenda. Scott presented the minutes from the prior
+meeting. After a motion and second, it was
+
+RESOLVED: That the minutes of the September 19, 2019 meeting of the
+Governing Board meeting of the Confidential Computing Consortium as
+distributed to the members of the Governing Board in advance of this
+meeting are hereby adopted and approved.
+
+Scott reviewed the membership and current recruitment status.
+
+Scott introduced the budget and walked through each line in the
+proposal. Scott asked that the Governing Board consider approving at
+least the Program Management and Marketing budget. Stephen discussed
+needs for OSS EU in Lyon coming up soon. Stephen encouraged the
+Governing Board to pass at least a partial budget to start doing things
+and in particular the Program Management support, helping with booth
+coverage and helping facilitate meetings. Discussion ensued supporting
+passing the budget. Stephen discussed starting a budget committee for
+building a longer term budget plan in a subcommittee.
+
+Stephen raised a question regarding the term of the budget approvals and
+Scott explained that budget approvals are on a 12-month basis and over
+the course of time will evolve to a calendar cycle.
+
+Stephen introduced the resolution. Gilad motioned, Philippe seconded the
+motion, and it was unanimously
+
+RESOLVED: That the budgeting of \$50,000 per calendar year on program
+management support and \$195,000 per year on Outreach activities (as
+detailed in the meeting materials) is hereby approved and adopted.
+
+Scott reviewed a potential election plan for election of the General
+Member Representative. Stephen suggested inviting any General Members in
+Lyon to join the Governing Board meeting in Lyon. Mike then asked
+whether it would be possible to defer elections until after Lyon.
+Discussion ensued around delaying the vote. The Governing Board settled
+on using a pre-Lyon General Member meeting as an engagement opportunity
+and to invite the General Members to attend the Lyon Governing Board
+meeting. The election will be deferred until after the Lyon meeting.
+Scott took an action item to setup a general member meeting prior to
+Lyon.
+
+Scott covered the TAC and Legal committee meetings. Philippe asked if
+there was interest in doing a face-to-face Legal committee meeting in
+Lyon. Discussion ensure around the role of the Legal Committee. Stephen
+summarized the discussion result as the Governing Board will use the OSS
+EU face-to-face meeting to setup an agenda of topics for the Legal
+Committee to discuss.
+
+Scott reviewed the plans for OSS EU in Lyon and the various activities
+planned for the event. Stephen discussed the reason for two
+birds-of-a-feather with OSS EU as they have different audiences. As
+there were no options for the day of Linux Security Summit, they chose
+an evening BoF the day before the Security Summit as the second BoF to
+try to capture the attendees that are available. Stephen discussed the
+panel approach for the Tuesday panel at OSS. Stephen discussed the
+exhibit booth space and encouraged others to participate in being
+available at the booth.
+
+Scott asked if there were any other questions before adjourning the
+meeting. Stephen suggested welcoming named alternative Governing Board
+members at the Lyon meeting and encourage them to participate in helping
+in the booth as well. Scott asked if the Governing Board approved of
+requesting named alternates of Governing Board members and the adding of
+those alternates to the meeting invites and Governing Board distribution
+list. The Governing Board expressed support for this.
+
+There being no other business to discuss, the meeting concluded at 10:56
+am US Eastern Time.

--- a/Board Meeting Minutes/CCC Board Minutes 2019-10-31.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2019-10-31.md
@@ -1,0 +1,196 @@
+**Confidential Computing Consortium**
+
+**Minutes of the Meeting of the Governing Board**
+
+**31 October 2019**
+
+**Members of the Governing Board Participating in the Meeting:**
+
+-   Stephen Walli (Microsoft) Chair
+
+-   Sergio Leunissen (Oracle)
+
+-   Gilad Golan (Google)
+
+-   Yongzheng Wu (Huawei)
+
+-   Jesse Schrater (Intel)
+
+-   Philippe Robin (Arm)
+
+-   Mike Bursell (Red Hat)
+
+General Members Attending:
+
+-   Richard Searle (Fortanix)
+
+-   Stefan Deml (deCentriq)
+
+Guests and Observers:
+
+-   Ben Fischer (Red Hat) Outreach
+
+-   Axel Simon (Red Hat)
+
+-   Haiwu He (iExec Blockchain Tech)
+
+-   Lei Zhang (iExec Blockchain Tech)
+
+-   Andras Slemmer (deCentriq)
+
+-   Simon Johnson (Intel) TAC
+
+-   Dave Thaler (Microsoft) TAC
+
+-   Nelly Porter (Google)
+
+**Not in attendance:**
+
+-   Xiaoning Li (Alibaba)
+
+**Roll Call and Introductions:** There was a roll call attendance, and
+introductions around the table as we had a few new attendees that had
+not participated in the Open Source Summit activities.
+
+**Anti-trust Reivew:** As this was a first face-to-face meeting and
+there were guests and general members present, we took a moment to
+review the anti-trust slide.
+
+**Previous Minutes:** We briefly reviewed the previous meeting minutes
+and accepted them.
+
+**RESOLVED**: That the minutes of the October 10, 2019 meeting of the
+Governing Board meeting of the Confidential Computing Consortium as
+distributed to the members of the Governing Board in advance of this
+meeting are hereby adopted and approved.
+
+Moved by Oracle, Seconded by Google. **Passed** 7, 0, 0. \[Yes, No,
+Abstain\]
+
+**Membership:** We reviewed the member list and status of new members
+and potential members. Microsoft met with AWS this week and will
+continue to meet with them in the coming weeks to encourage them to join
+and participate. Google and Red Hat will continue to work to encourage
+AMD to join.
+
+**Lyon Events:** We reviewed the week's events. There was:
+
+-   Two Birds-of-a-Feather meetings (Mon, Weds) for developers
+    presenting the three Consortium projects. Each was well attended
+    with 20+ additional attendees beyond the presenters.
+
+-   A panel discussion in the main conference. Intel moderated a
+    discussion with Red Hat, Fortanix, deCentriq, and Arm in the main
+    part of the conference. It was well attended (40-50).
+
+-   We sponsored a small booth.
+
+-   Everyone was happy with the engagement. Booth traffic was surprising
+    considering we had no collateral and only the main panel on the desk
+    as branding. Lots of good conversations and a constant flow of
+    traffic. There was consensus that most people seemed to be attending
+    two events (e.g. Booth and BoF, BoF and Panel, etc.)
+
+**Budget Discussion:** There was a good discussion as we work to refine
+our budget. Time was spent ensuring people understood how we arrived at
+the budget as it is (and the approval for the current working amount).
+
+-   Questions arose in the marketing and outreach section to better
+    understand what we've spent and how we might tune the plan from
+    Outreach members.
+
+-   The TAC representatives also queried what can and can't be done with
+    money that seems to be earmarked for the TAC.
+
+-   The Board felt it appropriate to push resolutions requesting each
+    committee to refine their asks against the budget.
+
+**RESOLVED**: That the Governing Board asks the Outreach Committee to
+provide more detailed budget feedback on their budget requirements.
+
+Moved by Oracle, Seconded by Red Hat. **Passed** 6, 0, 1. \[Yes, No,
+Abstain\]
+
+**RESOLVED**: That the Governing Board asks the Technical Advisory
+Committee to provide more detailed budget feedback on their budget
+requirements.
+
+Moved by Red Hat, Seconded by Oracle. **Passed** 6, 0, 1. \[Yes, No,
+Abstain\]
+
+**General Member Representative Election:** The governing board welcomed
+general members to the meeting such that they could get a sense of the
+work and get to know one another before committing to electing a
+governing board representative. We discussed how we wanted to start
+moving towards votes for roles in future in the Consortium. We felt
+anonymous elections were a good thing. We felted ranked Condorcet voting
+was a good thing. The Board resolved to modify the voting process.
+
+Text of the slide we discussed (modifications in yellow):
+
+> If the Governing Board is ready to start the General Member election
+> process, we would open an email nomination period on or about Friday,
+> November 1, to the General Members followed by a voting period where
+> votes would be cast via Condorcet ranked voting, organized by Stephano
+> Cetola, program manager to the project, at
+> <scetola@linuxfoundation.org>.
+> \[<https://en.wikipedia.org/wiki/Condorcet_method>\]
+
+**RESOLVED**: That the General Member Representative Election procedures
+
+as described above are hereby adopted and approved.
+
+Moved by Google, Seconded by Oracle. **Passed** 6, 0, 1. \[Yes, No,
+Abstain\]
+
+**Additional Agenda Topics:**
+
+1.  Red Hat, Intel, Google led a discussion on whether or not we should
+    include an additional lower non-voting tier of membership for
+    academic organizations. A number of them might have projects the
+    Consortium would welcome, and while it is not a requirement to be a
+    member to propose/submit a project, having a specific member class
+    may make it easier for such organizations to participate. The group
+    felt we needed more information and put an action on the chair to
+    investigate further and report back.
+
+2.  Google and Intel led a discussion around whether or not the
+    Consortium should be actively recruiting in certain vertical spaces
+    (e.g. Telco). The group discussed whether or not we were looking for
+    influence and knowledge that could be encourage through guests or
+    more direct involvement through membership participation. An action
+    was taken by Google to propose verticals and possible candidates for
+    discussion at the next meeting.
+
+3.  The group wants to better understand what our program manager can be
+    doing for us. An action was taken by the chair to invite Stephano to
+    present his role to each of the Governing Board, Outreach Committee,
+    and TAC for their next meetings.
+
+4.  The group discussed how we might ensure we better engage our members
+    across the globe for meetings (both teleconference and
+    face-to-face). An action was put on the chair to poll the membership
+    for opportunities to meet face-to-face and to better engage with one
+    another.
+
+**Action Items:**
+
+1.  \[Stephen Walli\] Send the budget to the TAC and Outreach Committee
+    so they may act on the requests for budget detail. \[**COMPLETE**\]
+
+2.  \[Stephen Walli\] Investigate what other organizations under the LF
+    umbrella have done with respect to academic members and report back
+    to the Board at the next Board meeting.
+
+3.  \[Nelly Porter\] Propose verticals and possible candidates
+    organizations where the Consortium might engage for policy purposes
+    or direct membership for discussion at the next meeting
+
+4.  \[Stephen Walli\] Invite our LF Program Manager to present to the
+    Governing Board, Outreach Committee, and TAC at their next meetings
+    such that we can all better understand their role.
+
+5.  \[Stephen Walli\] Poll the membership to gather information on how
+    we might better engage with one another (teleconference times and
+    face-to-face opportunities) as a global organization and report back
+    to the Board at the next meeting.

--- a/Board Meeting Minutes/CCC Board Minutes 2019-11-21.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2019-11-21.md
@@ -1,0 +1,92 @@
+**Governing Board Conference Call -- 7:00am PST**
+
+**Thursday 21 November 2019**
+
+1.  **Call to Order / Roll Call**
+
+    a.  **Premier Members of the CCC**
+
+        i.  Stephen Walli (Microsoft)\* Acting Chair
+
+        ii. Philippe Robin (Arm)\*
+
+        iii. Mike Bursell (Red Hat) \*
+
+        iv. Peixin Hou (Huawei)\*
+
+        v.  Mike Muomoto (Intel)\*
+
+        vi. Nelly Porter (Google)\*
+
+    b.  **Guests / Observers**
+
+        i.  Stephano Cetola (LF PM, Acting Secretary)
+
+        ii. Scott Nicholas (LF)
+
+        iii. Richard Searle (Fortanix)*
+
+        iv. Simon Johnson (Intel)*
+
+        v.  Yan Michalevsky (Anjuna)*
+
+    c.  **Not in attendance**
+
+        i.  Xiaoning Li -- (Alibaba)\*
+
+        ii. Sergio Leunissen (Oracle)\*
+
+        iii. Zhipeng Huang -- (Huawei)*
+
+        iv. Jesse Schrater (Intel)*
+
+        v.  Yongzheng Wu (Huawei)
+
+**\*voting member**
+
+2.  **Agenda Items & Motions**
+
+    a.  The board approves the minutes of the Oct 31, 2019 minutes.
+
+    b.  Mike Bursell (Red Hat) volunteers to be the treasurer. Nelly
+        volunteers as a Budget Committee member. The group thanks them
+        both for their time and work on this.
+
+    c.  The board resolves to allow general members to attend the board
+        meetings. (see: Resolution I from agenda)
+
+    d.  The board resolves to reserve the right to executive sessions
+        where only board members will be in attendance. (see: Resolution
+        II from agenda)
+
+    e.  The board resolves to publish (publicly) the minutes and
+        recordings of the board meetings. (see: Resolution III from
+        agenda)
+
+    f.  The board amends the Resolution III to not include the
+        recordings for security concerns.
+
+3.  **Action Items**
+
+    a.  \[Stephen\] Ask the Outreach Committee how they would like to
+        work with academic institutions.
+
+    b.  \[Scott\] Reach out to UC Berkley.
+
+    c.  \[Stephen\] Poll the membership to gather information on how we
+        might better engage with one another (teleconference times and
+        face-to-face opportunities) as a global organization and report
+        back to the Board at the next meeting.
+
+    d.  \[Scott, Mike, Simon\] Follow up on the SGX SDK project.
+
+    e.  \[Scott\] Send Stephano the documents for projects that wish to
+        join.
+
+    f.  \[Stephano\] Put project documents on the wiki.
+
+**Meeting adjourned at 8:02 am PST on November 21, 2019. The next
+conference call is scheduled for December 19.**
+
+**Respectfully submitted by Stephano Cetola, Acting Secretary, on
+November 21, 2019.**

--- a/Board Meeting Minutes/CCC Board Minutes 2019-12-19.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2019-12-19.md
@@ -1,0 +1,78 @@
+**Governing Board Conference Call -- 7:00am PST**
+
+**19 December 2019**
+
+1.  **Call to Order / Roll Call**
+
+    a.  **Premier Members of the CCC**
+
+        i.  Philippe Robin (Arm)\* Acting Chair
+
+        ii. Sergio Leunissen (Oracle)\*
+
+        iii. Mike Muomoto (Intel)\*
+
+        iv.*Nelly Porter (Google)\*
+
+    b.  **Guests / Observers**
+
+        i.  Stephano Cetola (LF PM, Acting Secretary)
+
+    c.  **Not in attendance**
+
+        i.  Xiaoning Li -- (Alibaba)\*
+
+        ii. Peixin Hou (Huawei)\*
+
+        iii. Mike Bursell (Red Hat) \*
+
+        iv. Stephen Walli (Microsoft)\*
+
+**\*voting member**
+
+2.  **Agenda Items & Motions**
+
+    a.  The board approves the minutes of the Nov 21, 2019 meeting.
+
+    b.  The Outreach Committee is working on documenting talking points
+        and a general "elevator pitch" for the CCC in order to frame
+        conversations with perspective projects, members, and academic
+        institutions. As those documents are available member companies
+        will begin outreach activities to academic institutions. We are
+        in early conversations with UC Berkley.
+
+    c.  Project progression document is available. More documents will
+        be forthcoming.
+
+        i.  <https://github.com/confidential-computing/governance>
+
+    d.  SGX SDK CCC Project finalization documentation is still in the
+        works. Scott is working with folks from Intel.
+
+    e.  We are working on where our next F2F can happen.
+        [SCaLE](https://www.socallinuxexpo.org/scale/18x) and
+        [RSA](https://www.rsaconference.com/usa) are possibilities.
+
+    f.  We would like to improve communication with the other groups. In
+        order to accomplish this, we will keep this mailing list open to
+        all subscribers and the general public (moderated) to post. The
+        list membership, however, will remain only Premium Member
+        representatives so that private conversations can take place.
+
+    g.  We will move forward next month with forming a Legal Committee.
+
+3.  **Action Items**
+
+    a.  \[Stephano\] Open the list up to non-subscriber, moderated
+        posts. Ensure the members of this group are Premium Members, TAC
+        chair, Outreach Chair, and General Members rep.
+
+    b.  \[Stephano\] Send out an email to the board requesting legal
+        representatives from each of the Premium Member organizations.
+        Work with Scott to setup a meeting sometime after January 20.
+
+**Meeting adjourned at 7:32 am PST on December 19, 2019. The next
+conference call is scheduled for January 16.**
+
+**Respectfully submitted by Stephano Cetola, Acting Secretary, on
+December 19, 2019.**

--- a/Board Meeting Minutes/CCC Board Minutes 2020-01-16.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2020-01-16.md
@@ -1,0 +1,66 @@
+**Governing Board Conference Call -- 7:00am PST**
+
+**16 January 2020**
+
+1.  **Call to Order / Roll Call**
+
+    a.  **Premier Members of the CCC**
+
+        i.  Philippe Robin (Arm)\*
+
+        ii. Sergio Leunissen (Oracle)\*
+
+        iii. Mike Bursell (Red Hat)\*
+
+        iv. Stephen Walli (Microsoft)\* Chair
+
+        v.  Ron Perez (Intel)*
+
+> **Guests / Observers**
+
+vi. Dave Thaler (Microsoft) (TAC Chair)
+
+vii. Richard Searle (Fortanix, General Member Rep)\*
+
+viii. Simon Johnson (Intel)
+
+ix. Stephano Cetola (Linux Foundation, Acting Secretary)
+
+b.  **Not in attendance**
+
+    i.  Xiaoning Li (Alibaba)*
+
+    ii. Peixin Hou (Huawei)*
+
+    iii. Nelly Porter (Google)*
+
+**\*voting member**
+
+2.  **Agenda Items & Motions**
+
+    a.  The board approves the minutes of the Dec 19, 2019 meeting with
+        2 abstentions.
+
+    b.  Approved minutes should be available to the public. Stephano
+        will find a good place for those minutes to live.
+
+    c.  The F2F will be held at 8am PST on Thursday February 27^th^ at
+        the Microsoft sales office at RSA.
+
+3.  **Action Items**
+
+    a.  \[Stephano\] Find a good location for approved board meeting
+        minutes to live.
+
+    b.  \[Stephano/Stephen\] Create a sign-up for folks planning on
+        attending the F2F at RSA.
+
+    c.  \[Stephano/Stephen\] Get feedback from Scott on where each
+        project's acceptance status is at, and report that back to the
+        list.
+
+**Meeting adjourned at 7:53 am PST on January 16, 2020. The next
+conference call is scheduled for February 13.**
+
+**Respectfully submitted by Stephano Cetola, Acting Secretary, on
+January 16, 2020.**

--- a/Board Meeting Minutes/CCC Board Minutes 2020-01-16.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2020-01-16.md
@@ -16,9 +16,10 @@
 
         v.  Ron Perez (Intel)*
 
-> **Guests / Observers**
+        vi. Dave Thaler (Microsoft) (TAC Chair)
 
-vi. Dave Thaler (Microsoft) (TAC Chair)
+
+> **Guests / Observers**
 
 vii. Richard Searle (Fortanix, General Member Rep)\*
 

--- a/Board Meeting Minutes/CCC Board Minutes 2020-02-13.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2020-02-13.md
@@ -1,0 +1,117 @@
+**Governing Board Conference Call -- 7:00am PST**
+
+**13 February 2020**
+
+1.  **Call to Order / Roll Call**
+
+    a.  **Premier Members of the CCC**
+
+        i.  Philippe Robin (Arm)\*
+
+        ii. Sergio Leunissen (Oracle)\*
+
+        iii. Mike Bursell (Red Hat)\*
+
+        iv. Dave Thaler (Microsoft)\* (TAC Chair)
+
+        v.  Ron Perez (Intel)\*
+
+        vi. Michael Cheng (Facebook)\*
+
+        vii. Gilad Golan (Google)\*
+
+> **Guests / Observers**
+
+i.  Richard Searle (Fortanix, General Member Rep)\*
+
+ii. Simon Johnson (Intel)
+
+iii. Stephano Cetola (Linux Foundation, Acting Secretary)
+
+     a.  **Not in attendance**
+
+         i.  Xiaoning Li (Alibaba)\*
+
+         ii. Peixin Hou (Huawei)\*
+
+**\*voting member**
+
+2.  **Agenda Items & Motions**
+
+    a.  The board approves the minutes of the January 16, 2019 meeting
+        with 2 abstentions.
+
+    b.  The board agrees to upload the minutes to GitHub once approved.
+        A link will be provided on the website.
+
+    c.  The board will review both the TAC scoping document and the
+        Outreach positioning document (to be sent to the list) at the
+        F2F.
+
+    d.  We want to have a canary associated around each project (note on
+        the website updated each month) saying "no government agency or
+        other body has asked us to put in a back door". This item has
+        been added to the Legal Committee meeting.
+
+    e.  Budget committee will meet at the face to face from 3pm-4pm.
+
+    f.  The Open Source Summit in Austin this June was proposed as the
+        possible next F2F.
+
+3.  **Action Item Review**
+
+    a.  \[Stephano\] Find a location for approved board meeting minutes
+        to live. \[**DONE**\]
+
+        i.  Options are: 1. Groups.io "Main Group", 2. GitHub, or 3. the
+            website.
+
+        ii. We may discuss budget items that may need to be less public.
+
+        iii. We may also have closed sessions.
+
+    b.  \[Stephano/Stephen\] Create a sign-up for the F2F at RSA.
+        \[**DONE**\]
+
+    c.  \[Stephano/Stephen\] Get feedback from Scott on where each
+        project's acceptance status is at, and report that back to the
+        list. Only waiting for the last of the "red tape" around moving
+        Intel SGX SDK over to the CCC. \[**PENDING**\]
+
+4.  **TAC Report**
+
+    a.  The TAC has captured their work in defining confidential
+        computing.
+
+    b.  <https://github.com/confidential-computing/governance/blob/master/scoping.md>
+
+    c.  In this document, there are two voting items for the Governing
+        Board to consider:
+
+        i.  Should the term "confidential computing" be narrowly
+            scoped to TEEs (or even only certain classes of TEE) or more
+            broadly defined? [Section 2](https://github.com/confidential-computing/governance/blob/master/scoping.md#markdown-header-2-fine-grained-questions) breaks
+            this question down further.
+
+        ii. Should the consortium's scope be narrowly scoped to
+            TEE-based projects, or be more inclusive?
+
+    d.  Please review the Executive Summary, specifically that there is
+        a narrower definition being recommended and that it aligns with
+        the Outreach positioning document they are currently working on.
+
+5.  **Action Items**
+
+    a.  \[Stephano\] Make approved minutes available on GitHub & link
+        from website.
+
+    b.  \[ALL\] Please review the TAC's [scoping
+        document](https://github.com/confidential-computing/governance/blob/master/scoping.md),
+        the Outreach document will be sent out prior to the F2F for
+        review.
+
+**Meeting adjourned at 8:00 am PST on February 13, 2020. The next
+conference call is scheduled for March 12.**
+
+**Respectfully submitted by Stephano Cetola, Acting Secretary, on
+February 13, 2020.**

--- a/Board Meeting Minutes/CCC Board Minutes 2020-02-27.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2020-02-27.md
@@ -43,7 +43,7 @@
 **Move to approve minutes**
 
 1.  The committee approves the minutes for the February 13, 2019
-    meetings (no abstentions, the TAC chair abstains).
+    meetings (no abstentions other than the TAC chair).
 
 **Action Item Review**
 

--- a/Board Meeting Minutes/CCC Board Minutes 2020-02-27.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2020-02-27.md
@@ -2,6 +2,44 @@
 
 **Wednesday 27 February 2020** 
 
+**Roll Call**  
+-	Stephen Walli, Governing Board Chair, Microsoft  
+-	Seth Knox, Chair of the Outreach Committee, Fortanix  
+-	Mike Bursell, Treasurer, Red Hat   
+-	Dave Thaler, TAC Chair, Microsoft  
+-	Mary Lee, Microsoft  
+-	Aeva van der Veen, Microsoft  
+-	Vikas Bhatia, Microsoft  
+-	Wim Coekaerts, Oracle  
+-	Nelly Porter, Google  
+-	Wenjing Chu, Futurewei  
+-	Raphael Auphan, Cosmian  
+-	Xiaoning Li, Alibaba  
+-	Philippe Robin, Arm  
+-	Anne Bertucio, Google  
+-	Howard Huang, Huawei  
+-	Ben Fischer, Red Hat  
+-	Jesse Schrater, Intel  
+-	Ron Perez, Intel  
+-	Naveen Cherukuri, Nvidia  
+-	Richard Searle, Fortanix  
+-	Omkhar Arasaratnam, JPMC  
+-	Morgan Akers, JPMC  
+-	Ariel Kit, Mellanox  
+-	Yu Ding, ByteDance  
+-	Zhengqin Luo, ByteDance  
+-	Jazz Kang, Swisscom  
+-	Brent Hollingsworth, AMD  
+-	Michael Lu, ARM  
+-	Simon Johnson, Intel  
+-	Maor Cohen, Kindite  
+-	David Dunn, VMware  
+-	Vikas Bhatia, Microsoft  
+-	Brandon Baker, Google  
+-	Stefan Deml, Descentriq  
+-	Stephano Cetola, Linux Foundation  
+
+
 **Move to approve minutes**
 
 1.  The committee approves the minutes for the February 13, 2019

--- a/Board Meeting Minutes/CCC Board Minutes 2020-02-27.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2020-02-27.md
@@ -1,0 +1,177 @@
+**Governing Board F2F -- 1:00pm PST**
+
+**Wednesday 27 February 2020** 
+
+**Move to approve minutes**
+
+1.  The committee approves the minutes for the February 13, 2019
+    meetings (no abstentions, the TAC chair abstains).
+
+**Action Item Review**
+
+1.  \[Stephano\] Make the **approved** minutes available on GitHub.
+    \[OUTSTANDING\]
+
+2.  \[Stephen\] Poll the membership to gather information on how we
+    might better engage with one another (teleconference times and
+    face-to-face opportunities) as a global organization and report back
+    to the Board at the next meeting. \[OUTSTANDING\]
+
+**Approval of the TAC & Outreach Proposals**
+
+1.  See the Outreach slides for both proposals.
+
+2.  Note that "Integrity" wording has been removed from the slides
+    before the vote.
+
+3.  These documents will help us speak with one voice and align our
+    goals internally.
+
+**Motions**
+
+1.  The Governing Board adopts and approves the Scoping statement of the
+    Technical Advisory Council for the work of the Confidential
+    Computing Consortium.
+
+    1.  **Passed** (no objections or abstentions)
+
+2.  The Governing Board adopts and approves the Messaging Framework from
+    the Outreach Committee for the work of the Confidential Computing
+    Consortium.
+
+    1.  **Passed** (no objections or abstentions)
+
+3.  The Governing Board would like to thank the Outreach Committee and
+    the TAC for their hard work with regards to these efforts.
+
+**Outreach Summary**
+
+1.  We have analyst briefings set up for March 18^th^ and April 14^th^,
+    see the slides for details.
+
+2.  We will be discussing highlighted topics for analysts in the coming
+    weeks.
+
+3.  There is a press release template that has been created by the
+    Outreach committee. We will work with new members to guide them
+    through that process.
+
+4.  We are also working on messaging around new members that have joined
+    recently and will be working with them to create announcements.
+
+**Morgan -- JPMC**
+
+1.  Morgan gave an overview of their mission, data management / protect,
+    and strategies.
+
+2.  This short 20-minute presentation begins at around 17 minutes into
+    recording \#2 of the face to face.
+
+3.  Action items below for continued discussion around several points in
+    this talk.
+
+**Budget Committee Update**
+
+1.  Please do join the committee to help us formulate suggestions for
+    the board to approve.
+
+2.  The committee will meet soon to work on requests from Outreach and
+    TAC.
+
+3.  We are working to get the projected revenue per month from the LF.
+    Part of the challenge here is the fact that many companies pay at
+    different frequencies.
+
+4.  Any questions please feel free to reach out to Mike, Stephano, or
+    Stephen and we will be happy to walk you through the budget as it is
+    quite confusing in its current state.
+
+**Legal Subcommittee Update**
+
+1.  First meeting occurred on February 14^th^.
+
+2.  Meetings will be published soon.
+
+3.  One of the questions that came up was Graphene:
+
+    1.  It is LGPL3, so do we care?
+
+    2.  The general consensus was that if it is an OSI approved license,
+        we are fine.
+
+    3.  Also, there are multiple Graphene projects (same name). So how
+        do we want to handle this?
+
+4.  We also discussed trademarking around the CCC and confidential
+    computing in general.
+
+    1.  We cannot trademark confidential computing.
+
+    2.  Today, we see no reason to trademark the CCC.
+
+5.  Canaries were a subject of discussion and will be covered again in
+    the legal meeting at the F2F.
+
+6.  Premier members can feel free to join this meeting **with your
+    counsel**. Please do not join unless your counsel is present.
+
+**Next Meeting**
+
+Linux Foundation Open Source Summit in Austin this June seems like the
+next natural meeting point (June 22-24). Stephano can work with the LF
+to reserve us a space, and we will have better support than Lyon as we
+should be able to get a room at the same hotel as the event.
+
+**Motions**
+
+1.  The Governing Board approves the formation of a subcommittee to
+    produce a plan for a User Council to engage with user organizations
+    to capture input for the Confidential Computing Consortium (e.g.
+    user cases, design patterns). The subcommittee will be chaired by
+    the governing board chair and all members and user organizations are
+    welcome to participate. The subcommittee is expected to report back
+    a plan in a governing board meeting cycle or two.
+
+    1.  **Passed** (no abstentions or objections)
+
+2.  The Governing Board approves the TAC expense for CI/CD pipeline
+    costs to support the Open Enclave SDK project over the next quarter
+    (approximately \$4K).
+
+    1.  **Passed** (no abstentions or objections)
+
+**Action Items**
+
+1.  \[Stephen\] With regards to Morgan's presentation, he brought up
+    different patterns that they use. We should form a subcommittee to
+    explore what patterns are available currently and how those align
+    with our project.
+
+    1.  His presentation is the ideal resource, but here are some
+        highlights:
+
+        1.  What user stories and use cases currently exist?
+
+        2.  What roots of trust are currently considered viable (e.g.
+            Cloud vs TEE)?
+
+        3.  How do we address clustering enclaves, and moving data
+            between them?
+
+        4.  How much trust can be put in the CSP, and what do the
+            regulators think here?
+
+2.  \[Dave Thaler\] Reach out to Omkhar and Morgan (JPMC) and invite
+    them to a conversation at a TAC meeting.
+
+3.  \[Stephen\] What behavior should we expect from developers on the
+    project from a legal standpoint? Also, in general, what does it mean
+    for developers when their project joins the CCC.
+
+4.  \[Stephen/Stephano\] Start the process of the F2F in Austin.
+
+**Meeting adjourned at 2:50 pm PST on February 27, 2020. The next
+conference call will be scheduled for Wednesday March 12.**
+
+**Respectfully submitted by Stephano Cetola, Acting Secretary, on March
+2, 2020.**

--- a/Board Meeting Minutes/CCC Board Minutes 2020-03-12.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2020-03-12.md
@@ -41,7 +41,7 @@
 2.  **Agenda Items & Motions**
 
     1.  The board approves the minutes of the February 27, 2020 meeting
-        with no abstentions or objections.
+        with no objections, and no abstentions other than the TAC chair.
 
     2.  The board approves the Outreach expense for Linux Foundation
         Creative Design Support Services at a 'PLUS' level for an annual

--- a/Board Meeting Minutes/CCC Board Minutes 2020-03-12.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2020-03-12.md
@@ -45,7 +45,7 @@
 
     2.  The board approves the Outreach expense for Linux Foundation
         Creative Design Support Services at a 'PLUS' level for an annual
-        cost of \$15,000. No abstentions or objections. It should be
+        cost of \$15,000. No objections, no abstentions other than the TAC chair. It should be
         noted that the budget subcommittee chair and budget committee
         member brought this to the board with the Outreach chair
         present.

--- a/Board Meeting Minutes/CCC Board Minutes 2020-03-12.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2020-03-12.md
@@ -6,7 +6,7 @@
 
     1.  **Premier Members of the CCC**
 
-        1.  Philippe Robin (Arm)\*
+        1.  Philippe Robin (Arm) (Acting Chair)\*
 
         2.  Sergio Leunissen (Oracle)\*
 

--- a/Board Meeting Minutes/CCC Board Minutes 2020-03-12.md
+++ b/Board Meeting Minutes/CCC Board Minutes 2020-03-12.md
@@ -1,0 +1,159 @@
+**Governing Board Conference Call -- 7:00am PST**
+
+**12 March 2020**
+
+1.  **Call to Order / Roll Call**
+
+    1.  **Premier Members of the CCC**
+
+        1.  Philippe Robin (Arm)\*
+
+        2.  Sergio Leunissen (Oracle)\*
+
+        3.  Mike Bursell (Red Hat)\*
+
+        4.  Dave Thaler (Microsoft)\* (TAC Chair)
+
+        5.  Ron Perez (Intel)\*
+
+        6.  Michael Cheng (Facebook)\*
+
+        7.  Gilad Golan (Google)\*
+
+        8.  Peixin Hou (Huawei)\*
+
+    2.  **Guests / Observers**
+
+        1.  Richard Searle (Fortanix, General Member Rep)\*
+
+        2.  Seth Knox (Outreach Chair)
+
+        3.  Simon Johnson (Intel)
+
+        4.  Stephano Cetola (Linux Foundation, Acting Secretary)
+
+    3.  **Not in attendance**
+
+        1.  Xiaoning Li (Alibaba)\* 
+
+        **\*voting member**
+
+2.  **Agenda Items & Motions**
+
+    1.  The board approves the minutes of the February 27, 2020 meeting
+        with no abstentions or objections.
+
+    2.  The board approves the Outreach expense for Linux Foundation
+        Creative Design Support Services at a 'PLUS' level for an annual
+        cost of \$15,000. No abstentions or objections. It should be
+        noted that the budget subcommittee chair and budget committee
+        member brought this to the board with the Outreach chair
+        present.
+
+3.  **Action Item Review**
+
+    1.  \[Stephen\] User subcommittee is under discussion. \[in
+        progress\]
+
+    2.  \[Dave\] is working with Morgan on the TAC (JPMC). \[done\]
+
+    3.  \[Stephen\] Bringing clarity to the different stages of new
+        project approval (TAC vs GB with regards to questions regarding
+        trademark search. \[in progress\]
+
+    4.  \[Stephen/Stephano\] Start the process of the F2F in Austin.
+        \[done\]
+
+4.  **Code of conduct**
+
+    1.  Stephano will create a distribution list which will be closed to
+        voting board members (<conduct@confidentialcomputing.io>) for
+        now, and will likely be changed in the future.
+
+    2.  The code of conduct will be updated via pull requests on GitHub.
+        TAC will head up those changes.
+
+    3.  The TAC is advised to recommend projects use the Contributor
+        Covenant 2.0, and if they want to use another code of conduct,
+        they should provide that document and highlight the differences.
+        This will be proposed to the board next meeting to vote on.
+
+    4.  As projects receive code of conduct complaints, they should
+        notify the reflector so that the CCC can stay informed of these
+        issues. This will also be brought up in the next governing board
+        meeting for a vote.
+
+    5.  The suggestion was made that we start all our meetings with a
+        Code of Conduct disclaimer. Stephen will research that and get
+        back to the board.
+
+    6.  Current Code of Conduct Complaints
+
+        1.  A complaint was raised on one of the CCC project's
+            repository. This essentially bled over onto a CCC repository
+            (governance). The initial complaint with regards to the
+            project has be addressed by the TAC and the project
+            leadership.
+
+        2.  The TAC GitHub repository where the complaint was logged
+            requires that we address this issue formally as the CCC
+            board. We will call an executive session of the governing
+            board on Wednesday the 18^th^ at 8:00am PST. This will be
+            voting members as well as the TAC chair (Dave) and the Linux
+            Foundation Program Manager (Stephano).
+
+5.  **User Engagement Subcommittee**
+
+    1.  Discussions with JPMC have been a very valuable part of adding
+        color to our decisions and speaking to their specific industry
+        and communities. This is an example of how user engagement can
+        be of value.
+
+    2.  Stephen will be having a discussion with the Linux Foundation
+        directly regarding these ideas.
+
+    3.  We want to minimize the barriers to joining this group is key as
+        we want this to be a strong end user committee.
+
+    4.  Ron and Seth have volunteered to help form this committee.
+
+    5.  Dave will put this on the agenda for next week's TAC to see if
+        folks would like to volunteer as members.
+
+6.  **Action Items**
+
+    1.  \[Stephano\] Make approved minutes available on GitHub & link
+        from website.
+
+    2.  \[Stephano\] Create a distribution list for conduct, currently
+        set to the governing board executive membership plus the TAC
+        chair. \[DONE\]
+
+    3.  \[Stephano\] Create an executive session meeting scheduled for
+        Wednesday the 18^th^ at 8AM PST. Send out reminders for folks.
+        \[1/2 DONE\]
+
+    4.  \[Stephen\] Prepare a list of items to vote on for the
+        executive session next week (on CoC).
+
+    5.  \[Stephen\] Add Dave to the roll call list slide.
+
+    6.  \[Stephen\] Return to the GB with a discussion around
+        canaries.
+
+    7.  \[Stephen\] Look into adding a CoC disclaimer along with our
+        antitrust disclaimer to be at the beginning of each meeting. Ron
+        and Seth both volunteer to help with this effort.
+
+    8.  \[Stephen\] Speak with the Linux Foundation regarding User
+        Engagement Subcommittee. Please also attend the next TAC on
+        Thursday the 19^th^ at 7AM PT to bring details for them to
+        consider.
+
+    9.  \[Dave\] Please add discussion around User Engagement.
+
+**Meeting adjourned at 8:00 am PST on March 12, 2020. The next
+conference call is scheduled for April 9th.**
+
+**Respectfully submitted by Stephano Cetola, Acting Secretary, on March
+12, 2020.**


### PR DESCRIPTION
Per the action item on February 13th:
The board agrees to upload the minutes to GitHub once approved.
A link will be provided on the website.

This patch completes the first part of that request.

Signed-off-by: Stephano Cetola <scetola@linuxfoundation.org>