### PR TITLE
Adding the list of names that sit behind the CoC email address

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -41,6 +41,20 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at conduct@confidentialcomputing.io. All complaints will be reviewed and investigated promptly and fairly.
 
+Members of the Governing Board on the reflector are: 
+Company | Representative | Email Address
+Alibaba | Xiaoning Li | xiaoning.li@alibaba-inc.com
+ARM | Philippe Robin | philippe.robin@arm.com
+Facebook | Michael Cheng | mfc@fb.com
+Google | Nelly Porter | nellyporter@google.com
+Huawei | Peixin Hou | peixin.hou@huawei.com
+Intel | Ron Perez | ronald.perez@intel.com
+Microsoft | Stephen Walli | stephen.walli@microsoft.com
+Oracle | Sergio Leunissen | sergio.leunissen@oracle.com
+Red Hat | Mike Bursell | mbursell@redhat.com
+TAC Chair | Dave Thaler | dthaler@microsoft.com
+General Member Rep | Richard Searle  | richard.searle@fortanix.com
+
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines


### PR DESCRIPTION
Ensure folks know who sits on the code-of-conduct reflector in case the concern being reported is with someone on the governing board itself.