### PR TITLE
Add CODEOWNERS file to auto-add TAC members as PR reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# Each line is a file pattern followed by one or more owners.
+# Refer to https://help.github.com/en/articles/about-code-owners
+
+# Order is important; the last matching pattern takes the most
+# precedence. Try to keep at least two owners per pattern.
+
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, they will be requested for
+# review when someone opens a pull request.
+* @dthaler @jethrogb @MikeCamel @hannibalhuang @jchax @glikely @GiuseppeGiordano @spjohnso @brandonb-work @jinsongyu-fb @bassbeat


### PR DESCRIPTION
Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>