### PR TITLE
Remove project specific votes in the TAC

### DIFF
--- a/project-progression-policy.md
+++ b/project-progression-policy.md
@@ -171,8 +171,8 @@ The Graduation stage is for projects that have reached their growth goals and ar
 **Expectations**
 
 Graduation stage projects are "TAC Projects" under the
-[Confidential Computing Consoritium Charter](https://confidentialcomputing.io/wp-content/uploads/sites/85/2019/12/CCC_Charter.pdf),
-and as such have a voting representative on the TAC. They are eligible to receive ongoing support from the Consortium as determined by the Governing Board, and are expected to cross promote the Consortium along with their activities.
+[Confidential Computing Consoritium Charter](https://confidentialcomputing.io/wp-content/uploads/sites/85/2019/12/CCC_Charter.pdf).
+They are eligible to receive ongoing support from the Consortium as determined by the Governing Board, and are expected to cross promote the Consortium along with their activities.
 
 **Acceptance Criteria**
 


### PR DESCRIPTION
Per the Governing Board resolution as presented to the TAC at the
September 17 meeting, this change is needed to make the project
progression policy document match the governing board resolution
reported in
https://lists.confidentialcomputing.io/g/governingboard/topic/governing_board_voting_on/76621014?p=,,,20,0,0,0::recentpostdate%2Fsticky,,,20,2,0,76621014

The TAC charter (section 7 of the CCC charter
https://confidentialcomputing.io/wp-content/uploads/sites/85/2019/12/CCC_Charter.pdf)
still needs to be updated too, but that is separate from this PR, and is covered by Issue #67

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>