### PR TITLE
Fix broken link to project submission template

### DIFF
--- a/project-progression-policy.md
+++ b/project-progression-policy.md
@@ -34,7 +34,7 @@ and a vote by the Governing Board.
 #### Technical Review
 
 Projects are required to present their proposal at a TAC meeting.
-This proposal should cover all the items in the [Project Progression Template](https://github.com/confidential-computing/governance/blob/master/project-progression-template.md)
+This proposal should cover all the items in the [Project Submission Template](https://github.com/confidential-computing/governance/blob/master/project-submission-template.md)
 and the [Technical Charter template](https://lists.confidentialcomputing.io/g/main/files/TAC/Project%20Submissions/Technical%20Charter%20%28custom+data%29%20--%20LF%20Projects,%20LLC%204-10-2019%20FINAL%20%2811%29.docx)).
 
 The TAC may ask for changes to bring the project into better alignment with


### PR DESCRIPTION
The project submission template was renamed from project progression
template at some point. Fix the project progression instructions to point
at the new name.