### PR TITLE
Add definition of a Growth Plan

### DIFF
--- a/growth-plans.md
+++ b/growth-plans.md
@@ -1,0 +1,28 @@
+# Growth Plans
+
+The [CCC Project Progression Policy](project-progression-policy.md) explains
+that each [Incubation Stage](project-progression-policy.md#incubation-stage)
+project accepted by the CCC must have a growth plan to track its progress
+towards the [Graduation Stage](project-progression-policy.md#graduation-stage).
+
+A "growth plan" is a written set of [growth goals](#growth-goals) and a
+written set of actions intended to make forward progress towards those goals.
+The growth plan does not need to have a fixed timeline.
+
+The growth plan is reviewed when a project enters the Incubation or
+Graduation Stake, and also as part of the project's
+[Annual Review Process](project-progression-policy.md#iv-annual-review-process).
+
+## Growth Goals
+
+A project's growth goals are, at minimum, the CCC criteria for achieving 
+Graduation Stage.
+
+As a bit of history, the notion of project "incubation" and "graduation" were
+[introduced](https://docs.openstack.org/project-team-guide/introduction.html)
+by OpenStack and have since been followed by
+[CNCF](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc)
+and other organizations, but the exact criteria vary by organization.
+
+Objective criteria for graduation are preferred rather than subjective criteria.
+Similarly, any additional growth goals should be objectively measurable.

--- a/growth-plans.md
+++ b/growth-plans.md
@@ -10,7 +10,7 @@ written set of actions intended to make forward progress towards those goals.
 The growth plan does not need to have a fixed timeline.
 
 The growth plan is reviewed when a project enters the Incubation or
-Graduation Stake, and also as part of the project's
+Graduation Stage, and also as part of the project's
 [Annual Review Process](project-progression-policy.md#iv-annual-review-process).
 
 ## Growth Goals
@@ -24,5 +24,5 @@ by OpenStack and have since been followed by
 [CNCF](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc)
 and other organizations, but the exact criteria vary by organization.
 
-Objective criteria for graduation are preferred rather than subjective criteria.
+Objective criteria for graduation are preferred rather than subjective criteria (TODO: update the CCC Graduation Stage criteria to be objective).
 Similarly, any additional growth goals should be objectively measurable.

--- a/project-progression-policy.md
+++ b/project-progression-policy.md
@@ -130,7 +130,7 @@ To be considered for the Sandbox Stage, the project must meet the following requ
 ### Incubation Stage
 **Definition**
 
-The Incubation stage is for projects that are interested in reaching the Graduation stage, and have identified a growth plan for doing so. Incubation stage projects will receive mentorship from the TAC and are expected to actively develop their community of contributors, governance, project documentation, and other variables identified in the growth plan that factor into broad success and adoption.
+The Incubation stage is for projects that are interested in reaching the Graduation stage, and have identified a [growth plan](growth-plans.md) for doing so. Incubation stage projects will receive mentorship from the TAC and are expected to actively develop their community of contributors, governance, project documentation, and other variables identified in the growth plan that factor into broad success and adoption.
 
 In order to support their active development, projects in the Incubation stage have a higher level of access to Consortium resources as provided by the Governing Board of the Consortium. A project's progress toward its growth plan goals will be reviewed on a yearly basis, and the TAC may move a project to the Sandbox stage if progress on the plan drops off or stalls.
 
@@ -159,7 +159,7 @@ To be considered for Incubation stage, the project must meet the Sandbox require
 ### Graduation Stage
 **Definition**
 
-The Graduation stage is for projects that have reached their growth goals and are now on a sustaining cycle of development, maintenance, and long-term support. Graduation stage projects are used commonly in enterprise production environments and have large, well-established project communities.
+The Graduation stage is for projects that have reached their [growth goals](growth-plans.md) and are now on a sustaining cycle of development, maintenance, and long-term support. Graduation stage projects are used commonly in enterprise production environments and have large, well-established project communities.
 
 **Examples**
 


### PR DESCRIPTION
Addresses part of issue #50

A separate PR will address the fact that some of the currently listed
graduation criteria are subjective.  (For some history, when the policy
document was accepted by the TAC as a starting point back in October 2019,
there were unresolved questions/issues on the Graduation stage that were
punted for later discussion since no projects are proposed for that
stage yet.)  That's closely related to this one, but the intent is to
decouple the two as separate PRs.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>