### PR TITLE
policy: add license scans to project reviews

### DIFF
--- a/project-progression-policy.md
+++ b/project-progression-policy.md
@@ -229,6 +229,10 @@ The review includes the following:
 
 3. Review any budget allocations relevant to the project, and whether any
    adjustments are needed.
+   
+4. Review license scans provided by the Linux Foundation. Provide feedback
+   on any outstanding issues and evaluate the scanning service from the
+   project's perspective.
 
 Projects are encouraged to proactively inform the TAC when something
 changes that affects their submission template or Technical Charter (changing a License, security


### PR DESCRIPTION
The Linux Foundation now provides the CCC projects with quarterly
license scanning. We would like to add these scans to the annual project
reviews to both review issues and to assess the value of the scans.

Signed-off-by: Stephano Cetola <scetola@linuxfoundation.org>