### PR TITLE
Add/update diversity and inclusion policies

### DIFF
--- a/diversity-and-inclusion-policies.md
+++ b/diversity-and-inclusion-policies.md
@@ -1,0 +1,50 @@
+# Diversity and Inclusion Policy Guidelines
+
+## Intro
+The Confidential Computing Consortium is a community focused on open source
+licensed projects securing DATA IN USE & accelerating the adoption of
+confidential computing through open collaboration.
+
+Every member is welcome; every project meeting our criteria is welcome. 
+We are a transparent, collaborative community.
+
+We as members, contributors, and leaders pledge to make participation
+in our community a harassment-free experience for everyone.
+
+
+## Policies
+The [Project Proposal Template](project-submission-template.md) specifies that
+a project must have a Code of Conduct to be submitted to the Confidential
+Computing Consortium.
+
+The [Project Progression Policy](project-submission-template.md) specifies
+additional community characteristics that a project must demonstrate for each
+stage.
+
+Each project is expected to develop an inclusive and diverse community.
+The means and specific goals may vary by project. The project's mentor is one
+resource available to assist in this area. A short list of additional resources
+and recommendations is provided in this document as an aid to projects.
+Projects are welcome to utilize additional resources as fit the needs of their
+communities.
+
+
+## Resources
+
+### Training
+Maintainers are recommended to take the Linux Foundation course: 
+[Inclusive Open Source Community Orientation](https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/) 
+
+Any contributor who may present in a CCC sponsored forum is recommended (and in
+some cases may be required) to take the Linux Foundation course:
+[Inclusive Speaker Orientation](https://training.linuxfoundation.org/resources/free-courses/inclusive-speaker-orientation/)
+
+### Inclusive writing style guides
+An open source best practice is to document style requirements. This makes it
+easier for new contributors to conform to community norms without guessing and
+reduces unproductive practices like "bike shedding". Example style guides
+include:
+https://github.com/torvalds/linux/blob/a5f526ecb075a08c4a082355020166c7fe13ae27/Documentation/process/coding-style.rst#4-naming
+https://docs.microsoft.com/en-us/style-guide/bias-free-communication
+https://developers.google.com/style/inclusive-documentation
+

--- a/diversity-and-inclusion-policies.md
+++ b/diversity-and-inclusion-policies.md
@@ -18,7 +18,7 @@ a project must have a Code of Conduct to be submitted to the Confidential
 Computing Consortium.
 
 The [Project Progression Policy](project-submission-template.md) specifies
-additional community characteristics that a project must demonstrate for each
+additional community characteristics for a project to demonstrate for each
 stage.
 
 Each project is expected to develop an inclusive and diverse community.

--- a/project-mentors.md
+++ b/project-mentors.md
@@ -26,7 +26,8 @@ Responsibilities of the mentor include:
 5. In order to be a coach to the project maintainers, be familiar with open
    source best practices for diversity and inclusion.  In particular be
    familiar with 
-   [diversity and inclusion policies](diversity-and-inclusion-policies.md).
+   [diversity and inclusion policies](diversity-and-inclusion-policies.md)
+   and make sure maintainers are aware of its recommendations.
 
 ## Current Mentors
 

--- a/project-mentors.md
+++ b/project-mentors.md
@@ -23,6 +23,11 @@ Responsibilities of the mentor include:
    any upcoming events where CCC projects are giving presentations. Report
    that information back to the TAC at their meetings.
 
+5. In order to be a coach to the project maintainers, be familiar with open
+   source best practices for diversity and inclusion.  In particular be
+   familiar with 
+   [diversity and inclusion policies](diversity-and-inclusion-policies.md).
+
 ## Current Mentors
 
 Currently accepted CCC projects have been assigned the following mentors:

--- a/project-progression-policy.md
+++ b/project-progression-policy.md
@@ -154,6 +154,7 @@ To be considered for Incubation stage, the project must meet the Sandbox require
  * Demonstrate a substantial, in the opinion of the TAC, ongoing flow of commits and merged contributions.
  * Demonstrate that the current level of community participation is sufficient to meet the goals outlined in the growth plan.
  * Since these metrics can vary significantly depending on the type, scope and size of a project, the TAC has final judgement over the level of activity that is adequate to meet these criteria.
+ * Demonstrate that the project is invested in growing a diverse and inclusive community. Resources and recommendations are available in [diversity and inclusion policies](diversity-and-inclusion-policies.md) and through your mentor.
  * Receive a two-thirds supermajority vote of the TAC to move to Incubation stage.
 
 ### Graduation Stage
@@ -180,7 +181,6 @@ To graduate from Sandbox or Incubation status, or for a new project to join as a
 
  * Have a defined governing body of at least 5 or more members (owners and core maintainers, or similar technical role), of which no more than 1/3 is affiliated with the same employer. In the case there are 5 governing members, 2 may be from the same employer.
 * Have a healthy number of committers from at least two organizations. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
-* Adopt a Code of Conduct.
 * Explicitly define a project governance and committer process. This is preferably laid out in a GOVERNANCE.md file and references a CONTRIBUTING.md and OWNERS.md file showing the current and emeritus committers.
 * Have a public list of project adopters or users for at least the primary repo (e.g., ADOPTERS.md or logos on the project website).
 * Other metrics as defined by the applying Project during the application process in cooperation with the TAC.


### PR DESCRIPTION
Per 2021-07-15 TAC meeting add diversity and inclusion recommendations.
Add a D&I policy document modeled on security-response-policies.md
Update progression policies to encourage demonstrating D&I best practices.
Update mentoring responsibilities to recognize D&I coaching.