### PR TITLE
Add information on internship programs

### DIFF
--- a/diversity-and-inclusion-policies.md
+++ b/diversity-and-inclusion-policies.md
@@ -49,4 +49,5 @@ https://docs.microsoft.com/en-us/style-guide/bias-free-communication
 https://developers.google.com/style/inclusive-documentation
 
 ### Internships
-The CCC TAC has [committed to support interns](./project-progression-policy.md#benefits-of-being-a-recognized-consortium-project) for CCC projects that meet the mentor requirements.
+The CCC TAC has [committed to support interns](./project-progression-policy.md#benefits-of-being-a-recognized-consortium-project)
+ for CCC projects that commit to the list of "Mentor Responsibilities" on the [Outreachy mentor page](https://www.outreachy.org/mentor/).

--- a/diversity-and-inclusion-policies.md
+++ b/diversity-and-inclusion-policies.md
@@ -48,3 +48,5 @@ https://github.com/torvalds/linux/blob/a5f526ecb075a08c4a082355020166c7fe13ae27/
 https://docs.microsoft.com/en-us/style-guide/bias-free-communication
 https://developers.google.com/style/inclusive-documentation
 
+### Internships
+The CCC TAC and Outreach committee have [committed to support interns](./project-mentors.md) for CCC projects that meet the mentor requirements.

--- a/diversity-and-inclusion-policies.md
+++ b/diversity-and-inclusion-policies.md
@@ -49,4 +49,4 @@ https://docs.microsoft.com/en-us/style-guide/bias-free-communication
 https://developers.google.com/style/inclusive-documentation
 
 ### Internships
-The CCC TAC and Outreach committee have [committed to support interns](./project-mentors.md) for CCC projects that meet the mentor requirements.
+The CCC TAC and Outreach committee have [committed to support interns](./project-progression-policy.md#benefits-of-being-a-recognized-consortium-project) for CCC projects that meet the mentor requirements.

--- a/diversity-and-inclusion-policies.md
+++ b/diversity-and-inclusion-policies.md
@@ -49,4 +49,4 @@ https://docs.microsoft.com/en-us/style-guide/bias-free-communication
 https://developers.google.com/style/inclusive-documentation
 
 ### Internships
-The CCC TAC and Outreach committee have [committed to support interns](./project-progression-policy.md#benefits-of-being-a-recognized-consortium-project) for CCC projects that meet the mentor requirements.
+The CCC TAC has [committed to support interns](./project-progression-policy.md#benefits-of-being-a-recognized-consortium-project) for CCC projects that meet the mentor requirements.

--- a/project-mentors.md
+++ b/project-mentors.md
@@ -43,5 +43,3 @@ The following projects are in the middle of the contribution process and have te
 
 * **[Occlum](https://occlum.io)**: [Zongmin Gu](https://github.com/guzongmin)
 * **[SGX SDK for Linux](https://github.com/intel/linux-sgx)**: [Simon Johnson](https://github.com/spjohnso)
-
-

--- a/project-mentors.md
+++ b/project-mentors.md
@@ -44,6 +44,4 @@ The following projects are in the middle of the contribution process and have te
 * **[Occlum](https://occlum.io)**: [Zongmin Gu](https://github.com/guzongmin)
 * **[SGX SDK for Linux](https://github.com/intel/linux-sgx)**: [Simon Johnson](https://github.com/spjohnso)
 
-## Internships
-The [TAC and Outreach committe have committed](https://lists.confidentialcomputing.io/g/main/files/TAC/Meetings/2021/09-Sept/TAC%20Minutes%202021-09-09.pdf) to fund one intern per CCC project that meets the mentorship guidelines.
 

--- a/project-mentors.md
+++ b/project-mentors.md
@@ -43,3 +43,7 @@ The following projects are in the middle of the contribution process and have te
 
 * **[Occlum](https://occlum.io)**: [Zongmin Gu](https://github.com/guzongmin)
 * **[SGX SDK for Linux](https://github.com/intel/linux-sgx)**: [Simon Johnson](https://github.com/spjohnso)
+
+## Internships
+The [TAC and Outreach committe have committed](https://lists.confidentialcomputing.io/g/main/files/TAC/Meetings/2021/09-Sept/TAC%20Minutes%202021-09-09.pdf) to fund one intern per CCC project that meets the mentorship guidelines.
+

--- a/project-progression-policy.md
+++ b/project-progression-policy.md
@@ -19,7 +19,7 @@ Some ways a project can benefit by becoming a Consortium-recognized project incl
 3. Participation: Participate and lead in the ongoing development of the confidential computing paradigm. All projects are assigned a [Mentor](project-mentors.md) to assist in the integration of your project to the Consortium and growth beyond that.
 4. Project Support: The Consortium can provide limited funds to support project communication and infrastructure costs for CI/CD.
 5. Outreach: Part of the Consortium's mission is to promote the use of confidential computing with various communities and hence its recognized projects, to deliver that outcome.
-6. Internships: The [TAC and Outreach committe have committed](https://lists.confidentialcomputing.io/g/main/files/TAC/Meetings/2021/09-Sept/TAC%20Minutes%202021-09-09.pdf) to fund one intern per CCC project that meets the mentorship guidelines.
+6. Internships: The [TAC and Outreach committe have committed](https://lists.confidentialcomputing.io/g/main/files/TAC/Meetings/2021/09-Sept/TAC%20Minutes%202021-09-09.pdf) to fund one intern per CCC project that meets the [mentorship guidelines](https://www.outreachy.org/mentor).
 
 ## II. Project Proposal Process
 

--- a/project-progression-policy.md
+++ b/project-progression-policy.md
@@ -19,7 +19,7 @@ Some ways a project can benefit by becoming a Consortium-recognized project incl
 3. Participation: Participate and lead in the ongoing development of the confidential computing paradigm. All projects are assigned a [Mentor](project-mentors.md) to assist in the integration of your project to the Consortium and growth beyond that.
 4. Project Support: The Consortium can provide limited funds to support project communication and infrastructure costs for CI/CD.
 5. Outreach: Part of the Consortium's mission is to promote the use of confidential computing with various communities and hence its recognized projects, to deliver that outcome.
-6. Internships: The [TAC and Outreach committe have committed](https://lists.confidentialcomputing.io/g/main/files/TAC/Meetings/2021/09-Sept/TAC%20Minutes%202021-09-09.pdf) to fund one intern per CCC project that meets the [mentorship guidelines](https://www.outreachy.org/mentor).
+6. Internships: The [TAC has committed](https://lists.confidentialcomputing.io/g/main/files/TAC/Meetings/2021/09-Sept/TAC%20Minutes%202021-09-09.pdf) to fund one intern per CCC project that meets the [mentorship guidelines](https://www.outreachy.org/mentor).
 
 ## II. Project Proposal Process
 

--- a/project-progression-policy.md
+++ b/project-progression-policy.md
@@ -19,6 +19,7 @@ Some ways a project can benefit by becoming a Consortium-recognized project incl
 3. Participation: Participate and lead in the ongoing development of the confidential computing paradigm. All projects are assigned a [Mentor](project-mentors.md) to assist in the integration of your project to the Consortium and growth beyond that.
 4. Project Support: The Consortium can provide limited funds to support project communication and infrastructure costs for CI/CD.
 5. Outreach: Part of the Consortium's mission is to promote the use of confidential computing with various communities and hence its recognized projects, to deliver that outcome.
+6. Internships: The [TAC and Outreach committe have committed](https://lists.confidentialcomputing.io/g/main/files/TAC/Meetings/2021/09-Sept/TAC%20Minutes%202021-09-09.pdf) to fund one intern per CCC project that meets the mentorship guidelines.
 
 ## II. Project Proposal Process
 

--- a/project-progression-policy.md
+++ b/project-progression-policy.md
@@ -19,7 +19,7 @@ Some ways a project can benefit by becoming a Consortium-recognized project incl
 3. Participation: Participate and lead in the ongoing development of the confidential computing paradigm. All projects are assigned a [Mentor](project-mentors.md) to assist in the integration of your project to the Consortium and growth beyond that.
 4. Project Support: The Consortium can provide limited funds to support project communication and infrastructure costs for CI/CD.
 5. Outreach: Part of the Consortium's mission is to promote the use of confidential computing with various communities and hence its recognized projects, to deliver that outcome.
-6. Internships: The [TAC has committed](https://lists.confidentialcomputing.io/g/main/files/TAC/Meetings/2021/09-Sept/TAC%20Minutes%202021-09-09.pdf) to fund one intern per CCC project that meets the [mentorship guidelines](https://www.outreachy.org/mentor).
+6. Internships: The [TAC has committed](https://lists.confidentialcomputing.io/g/main/files/TAC/Meetings/2021/09-Sept/TAC%20Minutes%202021-09-09.pdf) to fund one intern per CCC project that commits to the list of "Mentor Responsibilities" on the [Outreachy mentor page](https://www.outreachy.org/mentor/).
 
 ## II. Project Proposal Process
 


### PR DESCRIPTION
Adds information on internships that are available to projects which meet the mentorship
requirements. Currently links to the TAC minutes approving the initial round, but should be updated
each year to reflect the current process.

Signed-off-by: Brian Warner <brian@bdwarner.com>