### PR TITLE
add a file with TAC people & their roles

### DIFF
--- a/tac-composition.md
+++ b/tac-composition.md
@@ -1,0 +1,17 @@
+# TAC Personnel
+
+* Chair
+   * Dave Thaler (@dthaler), Microsoft
+* Vice chair
+   * Jethro Beekman (@jethrogb), Fortanix
+* Secretary
+   * Brian Warner (@brianwarner), Linux Foundation
+* Voting Members
+   * Giuseppe Giordano (@GiuseppeGiordano), Accenture
+   * Zongmin Gu (@guzongmin), Ant Group
+   * Thomas Fossati (@thomas-fossati), Arm
+   * Eric Northup, Facebook
+   * Iulia Ion (@iuliaion), Google
+   * Zhipeng Huang (@hannibalhuang), Huawei
+   * Dan Middleton (@dcmiddle), Intel
+   * Lily Sturmann (@lkatalin), RedHat

--- a/tac-composition.md
+++ b/tac-composition.md
@@ -1,17 +1,17 @@
 # TAC Personnel
 
 * Chair
-   * Dave Thaler (@dthaler), Microsoft
+   * Dan Middleton (@dcmiddle), Intel
 * Vice chair
    * Jethro Beekman (@jethrogb), Fortanix
 * Secretary
-   * Brian Warner (@brianwarner), Linux Foundation
+   * Kurt Taylor (@krtaylor), Linux Foundation
 * Voting Members
    * Giuseppe Giordano (@GiuseppeGiordano), Accenture
    * Zongmin Gu (@guzongmin), Ant Group
    * Thomas Fossati (@thomas-fossati), Arm
    * Eric Northup, Facebook
-   * Iulia Ion (@iuliaion), Google
+   * Cfir Cohen (@cfircohen), Google
    * Zhipeng Huang (@hannibalhuang), Huawei
-   * Dan Middleton (@dcmiddle), Intel
    * Lily Sturmann (@lkatalin), Red Hat
+   * Dave Thaler (@dthaler), Microsoft

--- a/tac-composition.md
+++ b/tac-composition.md
@@ -13,5 +13,5 @@
    * Eric Northup, Facebook
    * Cfir Cohen (@cfircohen), Google
    * Zhipeng Huang (@hannibalhuang), Huawei
-   * Lily Sturmann (@lkatalin), Red Hat
+   * Lily Sturmann (@lkatalin) and Yash Mankad (@yashkmankad ), Red Hat
    * Dave Thaler (@dthaler), Microsoft

--- a/tac-composition.md
+++ b/tac-composition.md
@@ -2,8 +2,6 @@
 
 * Chair
    * Dan Middleton (@dcmiddle), Intel
-* Vice chair
-   * Jethro Beekman (@jethrogb), Fortanix
 * Secretary
    * Kurt Taylor (@krtaylor), Linux Foundation
 * Voting Members

--- a/tac-composition.md
+++ b/tac-composition.md
@@ -14,4 +14,4 @@
    * Iulia Ion (@iuliaion), Google
    * Zhipeng Huang (@hannibalhuang), Huawei
    * Dan Middleton (@dcmiddle), Intel
-   * Lily Sturmann (@lkatalin), RedHat
+   * Lily Sturmann (@lkatalin), Red Hat

--- a/tac-github-process.md
+++ b/tac-github-process.md
@@ -4,8 +4,8 @@ The process that is currently in use by the TAC is as follows:
 
 1. The chair checks the issues and pull requests (PRs) to decide which, if any,
    should be on the next meeting agenda.
-2. All TAC members (not just the voting members) should have sent their
-   github ids to the chair and the Acting Secretary so any
+2. All [TAC members](CODEOWNERS) (not just the voting members) should have sent their
+   github ids to the [chair and the Acting Secretary](tac-composition.md) so any
    TAC PRs can have all TAC members as reviewers.
 3. Once PRs are approved by two TAC members (potentially including the author,
    if the author is a TAC member and doesn't indicate lack of explicit


### PR DESCRIPTION
Also, add links in the github process description that point to that file (and CODEOWNERS too).

Note that I couldn't find a list of TAC members apart from the voting reps.  The only (semi-official) source seems to be the CODEOWNERS file, but I'm not sure how accurate that is?