### PR TITLE
Add mediation to Code of Conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -58,6 +58,10 @@ Accenture | Michael Klein | michael.w.klein@accenture.com
 
 All reports will be reviewed and investigated promptly and fairly. Community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
+In matters that require an outside mediator, CCC has retained Mishi Choudhary (mishi@linux.com).
+Use of an outside mediator can be requested when reporting or used at the CCC Board's discretion.
+In general, contacting conduct@confidentialcomputing.io directly is preferred.
+
 ## Enforcement Guidelines
 
 Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:


### PR DESCRIPTION
Per discussion at TAC 2022-02-10 and thread https://lists.confidentialcomputing.io/g/tac/topic/staffing_coc_reporting/89022382

I copied wording [from CNCF for mediation](https://github.com/cncf/foundation/blob/main/code-of-conduct.md#reporting). Mike Dolan was also mentioned during our discussions as a contact for escalation/mediation in cases of conflict of interest. I welcome feedback on the most appropriate LF contact. Once this PR is resolved then we can add similar text to the project submission template so that projects can use this escalation / mediation path as well.