### PR TITLE
Rename stages per agreement in 2023-06-15 TAC meeting

### DIFF
--- a/growth-plans.md
+++ b/growth-plans.md
@@ -1,16 +1,14 @@
 # Growth Plans
 
 The [CCC Project Progression Policy](project-progression-policy.md) explains
-that each [Incubation Stage](project-progression-policy.md#incubation-stage)
-project accepted by the CCC must have a growth plan to track its progress
+project accepted by the CCC should have a growth plan to track its progress
 towards the [Graduation Stage](project-progression-policy.md#graduation-stage).
 
 A "growth plan" is a written set of [growth goals](#growth-goals) and a
 written set of actions intended to make forward progress towards those goals.
 The growth plan does not need to have a fixed timeline.
 
-The growth plan is reviewed when a project enters the Incubation or
-Graduation Stage, and also as part of the project's
+The growth plan is reviewed as part of the project's
 [Annual Review Process](project-progression-policy.md#iv-annual-review-process).
 
 ## Growth Goals
@@ -24,5 +22,5 @@ by OpenStack and have since been followed by
 [CNCF](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc)
 and other organizations, but the exact criteria vary by organization.
 
-Objective criteria for graduation are preferred rather than subjective criteria (TODO: update the CCC Graduation Stage criteria to be objective).
+Objective criteria for graduation are preferred rather than subjective criteria.
 Similarly, any additional growth goals should be objectively measurable.

--- a/project-mentors.md
+++ b/project-mentors.md
@@ -9,8 +9,7 @@ project and provide mentorship as needed.
 
 Responsibilities of the mentor include:
 
-1. Assist the project in creating a [growth plan](growth-plans.md), which is required for a
-   project in the [Incubation Stage](project-progression-policy.md#incubation-stage).
+1. Assist the project in creating a [growth plan](growth-plans.md).
 
 2. Help the project determine what needs to be reviewed by the TAC as
    part of the [annual review process](project-progression-policy.md#iv-annual-review-process).

--- a/project-progression-policy.md
+++ b/project-progression-policy.md
@@ -105,7 +105,7 @@ A project may want to spin out a new project because the original scope, governa
 In this case a new project acceptance proposal, as defined above, should be submitted to the TAC.
 
 ## III. Stages - Definitions & Expectations
-Every Consortium project has an associated maturity level. Proposed projects should state their preferred maturity level.  There are four maturity levels under this Project Progression Policy:
+Every Consortium project has an associated maturity level. Proposed projects should state their preferred maturity level.  There are three maturity levels under this Project Progression Policy:
 
 * Incubation - projects looking for a foundation with minimal initial resource requirements;
 * Graduation - projects that are used in production; and

--- a/project-progression-policy.md
+++ b/project-progression-policy.md
@@ -107,16 +107,16 @@ In this case a new project acceptance proposal, as defined above, should be subm
 ## III. Stages - Definitions & Expectations
 Every Consortium project has an associated maturity level. Proposed projects should state their preferred maturity level.  There are four maturity levels under this Project Progression Policy:
 
-* Sandbox - projects looking for a foundation with minimal initial resource requirements;
-* Incubation - projects that are used in production; and
+* Incubation - projects looking for a foundation with minimal initial resource requirements;
+* Graduation - projects that are used in production; and
 * Emeritus - projects that are approaching end-of-life.
 
 Representatives of Technical Projects may attend TAC meetings and contribute work regardless of their stage.
 
-### Sandbox Stage
+### Incubation Stage
 **Definition**
 
-The Sandbox stage is for projects that the TAC believes are, or have the potential to be, important to the ecosystem of Technical Projects or the ecosystem of the Consortium as a whole. They may be early-stage projects just getting started, or they may be long-established projects with minimal resource needs. The Sandbox stage provides a beneficial, neutral home for these projects in order to foster collaborative development and provide a path to deeper alignment with other Consortium projects via the project progression process.
+The Incubation stage is for projects that the TAC believes are, or have the potential to be, important to the ecosystem of Technical Projects or the ecosystem of the Consortium as a whole. They may be early-stage projects just getting started, or they may be long-established projects with minimal resource needs. The Incubation stage provides a beneficial, neutral home for these projects in order to foster collaborative development and provide a path to deeper alignment with other Consortium projects via the project progression process.
 
 **Examples**
 
@@ -126,22 +126,25 @@ The Sandbox stage is for projects that the TAC believes are, or have the potenti
 
 **Expectations**
 
-End users should evaluate Sandbox projects with care, as this stage does not set requirements for community size, governance, or production readiness. Sandbox projects will receive minimal support from the Consortium. Projects will be reviewed on an annual basis; they may also request a status review by submitting a report to the TAC.
+End users should evaluate Incubation projects with care, as this stage does not set requirements for community size, governance, or production readiness. Incubation projects will receive a basic level of support from the Consortium.
+
+Each project is expected to develop a [growth plan](growth-plans.md), and a project's progress toward its growth plan goals will be reviewed on a yearly basis, as discussed in the [Annual Review Process](#iv-annual-review-process).
+They may also request a status review by submitting a report to the TAC.
 
 **Acceptance Criteria**
 
-To be considered for the Sandbox Stage, the project must meet the following requirements:
+To be considered for the Incubation Stage, the project must meet the following requirements:
 * 1 [TAC representative](project-mentors.md) that will serve as a sponsor to champion the project & provide mentorship as needed
 * A presentation to at the meeting of the TAC
 
-* Upon acceptance, Sandbox projects must list their status prominently on their website/README
+* Upon acceptance, Incubation projects must list their status prominently on their website/README
 
-### Incubation Stage
+### Graduation Stage
 **Definition**
 
-The Incubation stage is for projects that have identified a [growth plan](growth-plans.md). Incubation stage projects will receive mentorship from the TAC and are expected to actively develop their community of contributors, governance, project documentation, and other variables identified in the growth plan that factor into broad success and adoption.
+Graduation stage projects will receive mentorship from the TAC and are expected to actively develop their community of contributors, governance, project documentation, and other variables identified in the growth plan that factor into broad success and adoption.
 
-In order to support their active development, projects in the Incubation stage have a higher level of access to Consortium resources as provided by the Governing Board of the Consortium. A project's progress toward its growth plan goals will be reviewed on a yearly basis, and the TAC may move a project to the Sandbox stage if progress on the plan drops off or stalls.
+In order to support their active development, projects in the Graduation stage have a higher level of access to Consortium resources as provided by the Governing Board of the Consortium. A project's progress toward its growth plan goals will be reviewed on a yearly basis, and the TAC may move a project to the Incubation stage if progress on the plan drops off or stalls.
 
 **Examples**
 
@@ -151,7 +154,7 @@ In order to support their active development, projects in the Incubation stage h
 
 **Acceptance Criteria**
 
-To be considered for Incubation stage, the project must meet the Sandbox requirements as well as the following:
+To be considered for Graduation stage, the project must meet the Incubation requirements as well as the following:
 
  * Development of a growth plan, to be done in conjunction with their [project mentor(s)](project-mentors.md) at the TAC.
  * Document that it is being used successfully in production by at least two independent end-user organizations which, in the TAC's judgement, are of adequate quality and scope.
@@ -159,7 +162,7 @@ To be considered for Incubation stage, the project must meet the Sandbox require
  * Demonstrate that the current level of community participation is sufficient to meet the goals outlined in the growth plan.
  * Since these metrics can vary significantly depending on the type, scope and size of a project, the TAC has final judgement over the level of activity that is adequate to meet these criteria.
  * Demonstrate that the project is invested in growing a diverse and inclusive community. Resources and recommendations are available in [diversity and inclusion policies](diversity-and-inclusion-policies.md) and through your mentor.
- * Receive a two-thirds supermajority vote of the TAC to move to Incubation stage.
+ * Receive a two-thirds supermajority vote of the TAC to move to Graduation stage.
 
 ### Emeritus Stage
 **Definition**

--- a/project-submission-template.md
+++ b/project-submission-template.md
@@ -36,5 +36,5 @@ the project; projects are free to use whatever governance structure they want.
 3.9. Names of initial committers, if different from those submitting proposal  
 3.10. List of project's official communication channels (slack, irc, mailing lists)  
 3.11. Project [Security Response Policy](security-response-policies.md)  
-3.12. Preferred maturity level (Sandbox, Incubation, Graduation, or Emeritus)  
+3.12. Preferred maturity level (Incubation, Graduation, or Emeritus)
 3.13. Any additional information the TAC and Board should take into consideration when reviewing your proposal.  


### PR DESCRIPTION
* Rename: Sandbox -> Incubation (as suggested by Lily during the meeting)
* Rename: Incubation -> Graduation (as suggested by Lily during the meeting)
* Remove remaining mentions of the old Graduation stage that were missed in PR #171
* Make growth plans be recommended at the first stage.  Previously the first stage had no mention, and the second stage required them, and they talked about movement toward the third stage.  Now that there is no third stage, the language needed to be updated.