### PR TITLE
First Attempt At Automating TSC Chair Notifications and Agenda

### DIFF
--- a/.github/scripts/parse-schedule.py
+++ b/.github/scripts/parse-schedule.py
@@ -22,18 +22,16 @@ def parse_schedule(path: str = "TAC/meeting-schedule.md") -> list[dict]:
 
     meetings = []
     for line in schedule_section.strip().splitlines():
-        # Match table rows with 5 columns:
-        # | Date | Rotating Chair | CCC Project Topic | TAC Goal Topic | Tech Talk |
+        # Match table rows with 3 columns:
+        # | Date | Rotating Chair | CCC Project Topic |
         match = re.match(
             r"\|\s*(\d{4}-\d{2}-\d{2})\s*\|"  # Date
             r"\s*(.*?)\s*\|"  # Rotating Chair
-            r"\s*(.*?)\s*\|"  # CCC Project Topic
-            r"\s*(.*?)\s*\|"  # TAC Goal Topic
-            r"\s*(.*?)\s*\|",  # TAC Tech Talk / Proposal / etc
+            r"\s*(.*?)\s*\|",  # CCC Project Topic
             line,
         )
         if match:
-            date_str, chair, project_topic, goal_topic, tech_talk = match.groups()
+            date_str, chair, project_topic = match.groups()
 
             # Skip "no meeting" rows
             if "no meeting" in chair.lower():
@@ -49,8 +47,6 @@ def parse_schedule(path: str = "TAC/meeting-schedule.md") -> list[dict]:
                     "date": date_str,
                     "chair": chair,
                     "project_topic": project_topic.strip(),
-                    "goal_topic": goal_topic.strip(),
-                    "tech_talk": tech_talk.strip(),
                 }
             )
 

--- a/.github/scripts/parse-schedule.py
+++ b/.github/scripts/parse-schedule.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Parse the TAC chair rotation schedule from TAC/chair-rotation.md.
+
+Reads the "2026 Meeting Schedule" table and returns meeting info as JSON.
+Used by GitHub Actions workflows for reminders and meeting prep.
+"""
+
+import json
+import re
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+def parse_schedule(path: str = "TAC/meeting-schedule.md") -> list[dict]:
+    """Parse the meeting schedule table from chair-rotation.md."""
+    content = Path(path).read_text()
+
+    # Find the 2026 Meeting Schedule section
+    schedule_section = content.split("## 2026 Meeting Schedule")[-1]
+
+    meetings = []
+    for line in schedule_section.strip().splitlines():
+        # Match table rows with 5 columns:
+        # | Date | Rotating Chair | CCC Project Topic | TAC Goal Topic | Tech Talk |
+        match = re.match(
+            r"\|\s*(\d{4}-\d{2}-\d{2})\s*\|"  # Date
+            r"\s*(.*?)\s*\|"  # Rotating Chair
+            r"\s*(.*?)\s*\|"  # CCC Project Topic
+            r"\s*(.*?)\s*\|"  # TAC Goal Topic
+            r"\s*(.*?)\s*\|",  # TAC Tech Talk / Proposal / etc
+            line,
+        )
+        if match:
+            date_str, chair, project_topic, goal_topic, tech_talk = match.groups()
+
+            # Skip "no meeting" rows
+            if "no meeting" in chair.lower():
+                continue
+
+            # Clean up chair field — skip TBD / placeholder entries
+            chair = chair.strip()
+            if "TBD" in chair or "<!--" in chair:
+                chair = ""
+
+            meetings.append(
+                {
+                    "date": date_str,
+                    "chair": chair,
+                    "project_topic": project_topic.strip(),
+                    "goal_topic": goal_topic.strip(),
+                    "tech_talk": tech_talk.strip(),
+                }
+            )
+
+    return meetings
+
+
+def find_next_meeting(meetings: list[dict], reference_date: datetime) -> dict | None:
+    """Find the next upcoming meeting on or after reference_date."""
+    for m in meetings:
+        meeting_date = datetime.strptime(m["date"], "%Y-%m-%d")
+        if meeting_date >= reference_date:
+            return m
+    return None
+
+
+def find_meeting_on(meetings: list[dict], target_date: str) -> dict | None:
+    """Find the meeting scheduled for a specific date."""
+    for m in meetings:
+        if m["date"] == target_date:
+            return m
+    return None
+
+
+def get_next_meeting_date(meetings: list[dict], after_date: str) -> str | None:
+    """Find the meeting date after the given date."""
+    found_current = False
+    for m in meetings:
+        if found_current:
+            return m["date"]
+        if m["date"] == after_date:
+            found_current = True
+    return None
+
+
+if __name__ == "__main__":
+    action = sys.argv[1] if len(sys.argv) > 1 else "next"
+    today = datetime.now()
+
+    meetings = parse_schedule()
+
+    if action == "next":
+        meeting = find_next_meeting(meetings, today)
+        if meeting:
+            meeting["next_date"] = get_next_meeting_date(meetings, meeting["date"]) or ""
+            print(json.dumps(meeting))
+        else:
+            print(json.dumps({"error": "No upcoming meetings found"}))
+
+    elif action == "this-week":
+        # Check if there's a meeting within the next 14 days.
+        # With the workflow running every Friday and meetings every 2 weeks,
+        # this ensures the chair gets two Friday reminders per meeting.
+        week_end = today + timedelta(days=14)
+        meeting = find_next_meeting(meetings, today)
+        if meeting:
+            meeting_date = datetime.strptime(meeting["date"], "%Y-%m-%d")
+            if meeting_date <= week_end:
+                meeting["next_date"] = (
+                    get_next_meeting_date(meetings, meeting["date"]) or ""
+                )
+                meeting["days_until"] = (meeting_date - today).days
+                print(json.dumps(meeting))
+            else:
+                print(json.dumps({"error": "No meeting this week"}))
+        else:
+            print(json.dumps({"error": "No upcoming meetings found"}))
+
+    elif action == "all":
+        print(json.dumps(meetings, indent=2))
+
+    else:
+        print(f"Unknown action: {action}", file=sys.stderr)
+        sys.exit(1)

--- a/.github/workflows/tac-chair-reminder.yml
+++ b/.github/workflows/tac-chair-reminder.yml
@@ -34,15 +34,11 @@ jobs:
           date=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('date',''))")
           chair=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('chair',''))")
           project_topic=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('project_topic',''))")
-          goal_topic=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('goal_topic',''))")
-          tech_talk=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tech_talk',''))")
           error=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error',''))")
 
           echo "date=$date" >> "$GITHUB_OUTPUT"
           echo "chair=$chair" >> "$GITHUB_OUTPUT"
           echo "project_topic=$project_topic" >> "$GITHUB_OUTPUT"
-          echo "goal_topic=$goal_topic" >> "$GITHUB_OUTPUT"
-          echo "tech_talk=$tech_talk" >> "$GITHUB_OUTPUT"
           echo "error=$error" >> "$GITHUB_OUTPUT"
 
           if [ -n "$error" ]; then
@@ -63,8 +59,6 @@ jobs:
           MEETING_DATE: ${{ steps.meeting.outputs.date }}
           CHAIR_NAME: ${{ steps.meeting.outputs.chair }}
           PROJECT_TOPIC: ${{ steps.meeting.outputs.project_topic }}
-          GOAL_TOPIC: ${{ steps.meeting.outputs.goal_topic }}
-          TECH_TALK: ${{ steps.meeting.outputs.tech_talk }}
         run: |
           # Format the date nicely
           formatted_date=$(date -d "$MEETING_DATE" "+%A, %B %-d, %Y" 2>/dev/null || echo "$MEETING_DATE")
@@ -72,19 +66,7 @@ jobs:
           # Build the agenda topics section dynamically
           topics=""
           if [ -n "$PROJECT_TOPIC" ]; then
-            topics="${topics}\n• *CCC Project:* ${PROJECT_TOPIC}"
-          fi
-          if [ -n "$GOAL_TOPIC" ]; then
-            topics="${topics}\n• *TAC Goal:* ${GOAL_TOPIC}"
-          fi
-          if [ -n "$TECH_TALK" ]; then
-            topics="${topics}\n• *Tech Talk / Proposal:* ${TECH_TALK}"
-          fi
-
-          if [ -n "$topics" ]; then
-            topics_section="\n\n*Scheduled Topics:*${topics}"
-          else
-            topics_section=""
+            topics="\n\n*Scheduled Topics:*\n• *CCC Project:* ${PROJECT_TOPIC}"
           fi
 
           curl -X POST "$SLACK_WEBHOOK_URL" \
@@ -92,6 +74,6 @@ jobs:
             --fail-with-body \
             -d @- <<EOF
           {
-            "text": "📋 *TAC Meeting Reminder*\n\n*Date:* ${formatted_date}\n*Time:* 8:00–9:00 am PT\n*Chair:* ${CHAIR_NAME}${topics_section}\n\n<https://zoom-lfx.platform.linuxfoundation.org/meeting/94618773737?password=4b2a5cdf-685a-4ea3-822d-24ff7ddab72e|Join Zoom Meeting>\n\n_${CHAIR_NAME} — as this week's chair, please prepare the agenda and share it with the TAC before the meeting. See the <https://github.com/confidential-computing/governance/blob/main/TAC/meeting-schedule.md|meeting schedule> for details._"
+            "text": "📋 *TAC Meeting Reminder*\n\n*Date:* ${formatted_date}\n*Time:* 8:00–9:00 am PT\n*Chair:* ${CHAIR_NAME}${topics}\n\n<https://zoom-lfx.platform.linuxfoundation.org/meeting/94618773737?password=4b2a5cdf-685a-4ea3-822d-24ff7ddab72e|Join Zoom Meeting>\n\n_${CHAIR_NAME} — as this week's chair, please prepare the agenda and share it with the TAC before the meeting. See the <https://github.com/confidential-computing/governance/blob/main/TAC/meeting-schedule.md|meeting schedule> for details._"
           }
           EOF

--- a/.github/workflows/tac-chair-reminder.yml
+++ b/.github/workflows/tac-chair-reminder.yml
@@ -1,0 +1,97 @@
+# Posts a reminder to Slack #ccc-tac about the upcoming TAC meeting chair
+# and scheduled topics.
+#
+# Runs every Friday at 15:00 UTC (8am PT) — gives the chair notice before
+# the Monday planning meetings.
+#
+# Required repository secret:
+#   SLACK_WEBHOOK_URL — Incoming Webhook URL for #ccc-tac
+#
+# The meeting schedule is read from TAC/meeting-schedule.md.
+
+name: TAC Chair Reminder
+
+on:
+  schedule:
+    # Every Friday at 15:00 UTC (8 am PT)
+    - cron: "0 15 * * 5"
+  workflow_dispatch: # Allow manual trigger for testing
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for meeting this week
+        id: meeting
+        run: |
+          result=$(python3 .github/scripts/parse-schedule.py this-week)
+          echo "json=$result" >> "$GITHUB_OUTPUT"
+
+          # Parse fields for later steps
+          date=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('date',''))")
+          chair=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('chair',''))")
+          project_topic=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('project_topic',''))")
+          goal_topic=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('goal_topic',''))")
+          tech_talk=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tech_talk',''))")
+          error=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error',''))")
+
+          echo "date=$date" >> "$GITHUB_OUTPUT"
+          echo "chair=$chair" >> "$GITHUB_OUTPUT"
+          echo "project_topic=$project_topic" >> "$GITHUB_OUTPUT"
+          echo "goal_topic=$goal_topic" >> "$GITHUB_OUTPUT"
+          echo "tech_talk=$tech_talk" >> "$GITHUB_OUTPUT"
+          echo "error=$error" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$error" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "ℹ️ $error — skipping reminder."
+          elif [ -z "$chair" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "⚠️ Meeting on $date has no chair assigned — skipping reminder."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "📣 Meeting on $date — chair: $chair"
+          fi
+
+      - name: Post to Slack
+        if: steps.meeting.outputs.skip == 'false'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          MEETING_DATE: ${{ steps.meeting.outputs.date }}
+          CHAIR_NAME: ${{ steps.meeting.outputs.chair }}
+          PROJECT_TOPIC: ${{ steps.meeting.outputs.project_topic }}
+          GOAL_TOPIC: ${{ steps.meeting.outputs.goal_topic }}
+          TECH_TALK: ${{ steps.meeting.outputs.tech_talk }}
+        run: |
+          # Format the date nicely
+          formatted_date=$(date -d "$MEETING_DATE" "+%A, %B %-d, %Y" 2>/dev/null || echo "$MEETING_DATE")
+
+          # Build the agenda topics section dynamically
+          topics=""
+          if [ -n "$PROJECT_TOPIC" ]; then
+            topics="${topics}\n• *CCC Project:* ${PROJECT_TOPIC}"
+          fi
+          if [ -n "$GOAL_TOPIC" ]; then
+            topics="${topics}\n• *TAC Goal:* ${GOAL_TOPIC}"
+          fi
+          if [ -n "$TECH_TALK" ]; then
+            topics="${topics}\n• *Tech Talk / Proposal:* ${TECH_TALK}"
+          fi
+
+          if [ -n "$topics" ]; then
+            topics_section="\n\n*Scheduled Topics:*${topics}"
+          else
+            topics_section=""
+          fi
+
+          curl -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --fail-with-body \
+            -d @- <<EOF
+          {
+            "text": "📋 *TAC Meeting Reminder*\n\n*Date:* ${formatted_date}\n*Time:* 8:00–9:00 am PT\n*Chair:* ${CHAIR_NAME}${topics_section}\n\n<https://zoom-lfx.platform.linuxfoundation.org/meeting/94618773737?password=4b2a5cdf-685a-4ea3-822d-24ff7ddab72e|Join Zoom Meeting>\n\n_${CHAIR_NAME} — as this week's chair, please prepare the agenda and share it with the TAC before the meeting. See the <https://github.com/confidential-computing/governance/blob/main/TAC/meeting-schedule.md|meeting schedule> for details._"
+          }
+          EOF

--- a/.github/workflows/tac-meeting-prep.yml
+++ b/.github/workflows/tac-meeting-prep.yml
@@ -35,16 +35,12 @@ jobs:
           chair=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('chair',''))")
           next_date=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('next_date',''))")
           project_topic=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('project_topic',''))")
-          goal_topic=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('goal_topic',''))")
-          tech_talk=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tech_talk',''))")
           error=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error',''))")
 
           echo "date=$date" >> "$GITHUB_OUTPUT"
           echo "chair=$chair" >> "$GITHUB_OUTPUT"
           echo "next_date=$next_date" >> "$GITHUB_OUTPUT"
           echo "project_topic=$project_topic" >> "$GITHUB_OUTPUT"
-          echo "goal_topic=$goal_topic" >> "$GITHUB_OUTPUT"
-          echo "tech_talk=$tech_talk" >> "$GITHUB_OUTPUT"
           echo "error=$error" >> "$GITHUB_OUTPUT"
 
           if [ -n "$error" ]; then
@@ -76,8 +72,6 @@ jobs:
           CHAIR: ${{ steps.meeting.outputs.chair }}
           NEXT_DATE: ${{ steps.meeting.outputs.next_date }}
           PROJECT_TOPIC: ${{ steps.meeting.outputs.project_topic }}
-          GOAL_TOPIC: ${{ steps.meeting.outputs.goal_topic }}
-          TECH_TALK: ${{ steps.meeting.outputs.tech_talk }}
           FOLDER: ${{ steps.check.outputs.folder }}
         run: |
           mkdir -p "$FOLDER"
@@ -92,8 +86,6 @@ jobs:
             -e "s/{{CHAIR}}/${CHAIR}/g" \
             -e "s/{{NEXT_DATE}}/${next_formatted}/g" \
             -e "s/{{PROJECT_TOPIC}}/${PROJECT_TOPIC}/g" \
-            -e "s/{{GOAL_TOPIC}}/${GOAL_TOPIC}/g" \
-            -e "s/{{TECH_TALK}}/${TECH_TALK}/g" \
             TAC/Meetings/agenda-template.md > "${FOLDER}/CCC_TAC_Meeting_Minutes_${MEETING_DATE}.md"
 
           echo "✅ Created ${FOLDER}/CCC_TAC_Meeting_Minutes_${MEETING_DATE}.md"
@@ -112,8 +104,6 @@ jobs:
 
             **Scheduled Topics:**
             - **CCC Project:** ${{ steps.meeting.outputs.project_topic || 'TBD' }}
-            - **TAC Goal:** ${{ steps.meeting.outputs.goal_topic || 'TBD' }}
-            - **Tech Talk / Proposal:** ${{ steps.meeting.outputs.tech_talk || 'TBD' }}
 
             This PR creates the meeting folder and agenda template. The chair should update the agenda before the meeting.
 

--- a/.github/workflows/tac-meeting-prep.yml
+++ b/.github/workflows/tac-meeting-prep.yml
@@ -1,0 +1,123 @@
+# Automatically creates the meeting folder and agenda file for the next TAC
+# meeting by opening a PR.
+#
+# Runs every Friday at 14:00 UTC (7am PT) — one hour before the reminder.
+# Only creates the PR if the meeting folder doesn't already exist.
+#
+# The meeting schedule is read from TAC/meeting-schedule.md.
+# The agenda is generated from TAC/Meetings/agenda-template.md.
+
+name: TAC Meeting Prep
+
+on:
+  schedule:
+    # Every Friday at 14:00 UTC (7 am PT)
+    - cron: "0 14 * * 5"
+  workflow_dispatch: # Allow manual trigger for testing
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for meeting this week
+        id: meeting
+        run: |
+          result=$(python3 .github/scripts/parse-schedule.py this-week)
+
+          date=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('date',''))")
+          chair=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('chair',''))")
+          next_date=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('next_date',''))")
+          project_topic=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('project_topic',''))")
+          goal_topic=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('goal_topic',''))")
+          tech_talk=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tech_talk',''))")
+          error=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error',''))")
+
+          echo "date=$date" >> "$GITHUB_OUTPUT"
+          echo "chair=$chair" >> "$GITHUB_OUTPUT"
+          echo "next_date=$next_date" >> "$GITHUB_OUTPUT"
+          echo "project_topic=$project_topic" >> "$GITHUB_OUTPUT"
+          echo "goal_topic=$goal_topic" >> "$GITHUB_OUTPUT"
+          echo "tech_talk=$tech_talk" >> "$GITHUB_OUTPUT"
+          echo "error=$error" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$error" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "ℹ️ $error — skipping meeting prep."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "📁 Will prepare meeting folder for $date (chair: $chair)"
+          fi
+
+      - name: Check if folder already exists
+        if: steps.meeting.outputs.skip == 'false'
+        id: check
+        run: |
+          year=$(echo "${{ steps.meeting.outputs.date }}" | cut -d- -f1)
+          folder="TAC/Meetings/${year}/${{ steps.meeting.outputs.date }}"
+          if [ -d "$folder" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "📂 Folder $folder already exists — skipping."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "folder=$folder" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate agenda from template
+        if: steps.meeting.outputs.skip == 'false' && steps.check.outputs.exists == 'false'
+        env:
+          MEETING_DATE: ${{ steps.meeting.outputs.date }}
+          CHAIR: ${{ steps.meeting.outputs.chair }}
+          NEXT_DATE: ${{ steps.meeting.outputs.next_date }}
+          PROJECT_TOPIC: ${{ steps.meeting.outputs.project_topic }}
+          GOAL_TOPIC: ${{ steps.meeting.outputs.goal_topic }}
+          TECH_TALK: ${{ steps.meeting.outputs.tech_talk }}
+          FOLDER: ${{ steps.check.outputs.folder }}
+        run: |
+          mkdir -p "$FOLDER"
+
+          # Format date for display
+          formatted_date=$(date -d "$MEETING_DATE" "+%B %-d, %Y" 2>/dev/null || echo "$MEETING_DATE")
+          next_formatted=$(date -d "$NEXT_DATE" "+%B %-d, %Y" 2>/dev/null || echo "$NEXT_DATE")
+
+          # Generate agenda from template with placeholder substitution
+          sed \
+            -e "s/{{DATE}}/${formatted_date}/g" \
+            -e "s/{{CHAIR}}/${CHAIR}/g" \
+            -e "s/{{NEXT_DATE}}/${next_formatted}/g" \
+            -e "s/{{PROJECT_TOPIC}}/${PROJECT_TOPIC}/g" \
+            -e "s/{{GOAL_TOPIC}}/${GOAL_TOPIC}/g" \
+            -e "s/{{TECH_TALK}}/${TECH_TALK}/g" \
+            TAC/Meetings/agenda-template.md > "${FOLDER}/CCC_TAC_Meeting_Minutes_${MEETING_DATE}.md"
+
+          echo "✅ Created ${FOLDER}/CCC_TAC_Meeting_Minutes_${MEETING_DATE}.md"
+
+      - name: Create Pull Request
+        if: steps.meeting.outputs.skip == 'false' && steps.check.outputs.exists == 'false'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: "meeting-prep-${{ steps.meeting.outputs.date }}"
+          commit-message: "Add meeting folder for ${{ steps.meeting.outputs.date }}"
+          title: "TAC Meeting Prep: ${{ steps.meeting.outputs.date }}"
+          body: |
+            Automated meeting prep for the TAC meeting on **${{ steps.meeting.outputs.date }}**.
+
+            **Chair:** ${{ steps.meeting.outputs.chair }}
+
+            **Scheduled Topics:**
+            - **CCC Project:** ${{ steps.meeting.outputs.project_topic || 'TBD' }}
+            - **TAC Goal:** ${{ steps.meeting.outputs.goal_topic || 'TBD' }}
+            - **Tech Talk / Proposal:** ${{ steps.meeting.outputs.tech_talk || 'TBD' }}
+
+            This PR creates the meeting folder and agenda template. The chair should update the agenda before the meeting.
+
+            ---
+            _Generated by the [TAC Meeting Prep](https://github.com/confidential-computing/governance/blob/main/.github/workflows/tac-meeting-prep.yml) workflow._
+          labels: "tac-meeting"
+          delete-branch: true

--- a/TAC/Meetings/agenda-template.md
+++ b/TAC/Meetings/agenda-template.md
@@ -1,0 +1,73 @@
+# Confidential Computing Consortium
+
+## Minutes of the Technical Advisory Council
+
+*The TAC meets for two hours on alternating Thursdays. All members of the community are welcome to attend and participate.*
+
+### Meeting details
+
+**Date**: Thursday, {{DATE}}
+
+**Time**: 8a-9a US Pacific Time
+
+* **Zoom**: [https://zoom-lfx.platform.linuxfoundation.org/meeting/94618773737?password=4b2a5cdf-685a-4ea3-822d-24ff7ddab72e](https://zoom-lfx.platform.linuxfoundation.org/meeting/94618773737?password=4b2a5cdf-685a-4ea3-822d-24ff7ddab72e)
+
+* **Calendar**: [https://calendar.confidentialcomputing.io](https://calendar.confidentialcomputing.io),
+[ical](https://calendar.google.com/calendar/ical/c\_c0pcihr7n2n1k3a38i32d9ag10%40group.calendar.google.com/public/basic.ics),
+[Google Calendar](https://calendar.google.com/calendar/u/0/r?cid=c\_c0pcihr7n2n1k3a38i32d9ag10@group.calendar.google.com)
+
+* **Recordings**: [YouTube TAC Playlist](https://www.youtube.com/playlist?list=PLmfkUJc39uMjaB_I1dYW72I44kr9QzG_B)
+
+## Links
+
+* **Code of Conduct**: [code-of-conduct.confidentialcomputing.io](https://code-of-conduct.confidentialcomputing.io)
+* **CCC Charter**: [charter.confidentialcomputing.io](https://charter.confidentialcomputing.io)
+* **LF Training course on DEI**: [Inclusive Open Source Community Orientation (LFC102) (free)](https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/)
+* **Declared project dependencies**: [Google Sheets](https://docs.google.com/spreadsheets/d/1UKnbbGWXYLjnPZsox3zmYo59nv3XSXjePfas5E2fER0/edit#gid=0)
+* **CCC YouTube**: [youtube.confidentialcomputing.io](https://youtube.confidentialcomputing.io)
+* **LFX**: [lfx.linuxfoundation.org](https://lfx.linuxfoundation.org)
+* **Join the CCC**: [join.confidentialcomputing.io](https://join.confidentialcomputing.io)
+* **Contact the CCC**: [confidentialcomputing.io/contact-us/](https://confidentialcomputing.io/contact-us/)
+
+## Agenda and Minutes
+
+### Welcome
+
+**Chair**: {{CHAIR}}
+
+* Chair opens the call
+* Chair welcomes the members of the TAC and reviews the values of the CCC and the antitrust policy of the Linux Foundation
+* Chair reviews the agenda
+
+### Roll Call / Attendance
+
+#### Voting members of the TAC
+
+*Per the [charter](https://charter.confidentialcomputing.io), all [CCC Premier members](https://confidentialcomputing.io/members/) receive one vote on the TAC. Quorum for votes is at least 50% of voting members present.*
+
+* AMD - Nathaniel McCallum / David Kaplan
+* Google - Rene Kolga / Keith Moyer
+* Huawei - Zhipeng (Howard) Huang
+* Intel - Raynor Scott / Simon Johnson
+* Meta - Henry Wang / Kevin Hui
+* Microsoft - Alec Fernandez
+* Nvidia - Fritz Alder / Dan Middleton
+* Red Hat - Yash Mankad / Ram Pai
+* TikTok - Mingshen Sun / Yao Zhang
+* Shielded Technologies - Bob Blessing-Hartley
+
+#### Other Attendees
+
+### Meeting Minute Approval & Old Business
+
+### Announcements
+
+### CCC Project Review: {{PROJECT_TOPIC}}
+
+### TAC Goal Discussion: {{GOAL_TOPIC}}
+
+### Tech Talk / Proposal: {{TECH_TALK}}
+
+### Any Other Business / Next Steps
+
+* Next meeting is scheduled on Thursday, {{NEXT_DATE}}.

--- a/TAC/meeting-schedule.md
+++ b/TAC/meeting-schedule.md
@@ -14,31 +14,31 @@ The TAC uses a rotating chair model. Each meeting is facilitated by a different 
 <!-- The GitHub Action reads this table to determine the current chair and meeting topics. -->
 <!-- Dates must be in YYYY-MM-DD format. -->
 
-| Date | Rotating Chair | CCC Project Topic | TAC Goal Topic | TAC Tech Talk / Proposal / etc |
-|------|---------------|-------------------|----------------|-------------------------------|
-| 2026-01-08 | *no meeting* | | | |
-| 2026-01-22 | Just Dan & Ijlal | Project grant discussion in light of '26 re-budget | Guidance docs | Attested HTTPs Rudiger et al |
-| 2026-02-05 | Nathaniel McCallum | Project grant discussion in light of '26 re-budget | NIST RFI; Blueprints docs | TAC Tech Talk Topic Triage (Fritz) Policy and Attestation (Mike B) |
-| 2026-02-19 | Rene Kolga / Keith Moyer | OpenVMM | NIST RFI; Blueprints docs | TAC Tech Talk Topic Triage (Fritz) |
-| 2026-03-05 | Wu Yongzheng | | NIST RFI; Blueprints docs | |
-| 2026-03-19 | Scott Raynor | | Board meeting download; OC3 Recap; PRs | Blueprints docs; Platform Ownership Endorsements (POE) Scott - Need to reschedule |
-| 2026-04-02 | Ahmed Magdy | Enarx | Finalize Blueprints | Platform Ownership Endorsements (POE) Scott |
-| 2026-04-16 | Alec Fernandez | Gramine | ISO | |
-| 2026-04-30 | Fritz Alder | COCONUT-SVSM | | |
-| 2026-05-14 | Yash Mankad / Ram Pai | Keystone | | |
-| 2026-05-28 | Bob Blessing-Hartley | SPDM-RS | | |
-| 2026-06-11 | Mingshen Sun | OE SDK | | |
-| 2026-06-25 | Nathaniel McCallum | | | |
-| 2026-07-09 | Rene Kolga / Keith Moyer | Veraison | | |
-| 2026-07-23 | Wu Yongzheng | Occulum | | |
-| 2026-08-06 | Scott Raynor | Certifier Framework | | |
-| 2026-08-20 | Ahmed Magdy | VirTEE | | |
-| 2026-09-03 | Alec Fernandez | dstack | | |
-| 2026-09-17 | Fritz Alder | ManaTEE | | |
-| 2026-10-01 | Yash Mankad / Ram Pai | | | |
-| 2026-10-15 | Bob Blessing-Hartley | | | |
-| 2026-10-29 | Mingshen Sun | | | |
-| 2026-11-12 | Nathaniel McCallum | | | |
-| 2026-11-26 | Rene Kolga / Keith Moyer | Islet | | |
-| 2026-12-10 | Wu Yongzheng | | | |
-| 2026-12-24 | Scott Raynor | | | |
+| Date | Rotating Chair | CCC Project Topic |
+|------|---------------|-------------------|
+| 2026-01-08 | *no meeting* | |
+| 2026-01-22 | Just Dan & Ijlal | Project grant discussion in light of '26 re-budget |
+| 2026-02-05 | Nathaniel McCallum | Project grant discussion in light of '26 re-budget |
+| 2026-02-19 | Rene Kolga / Keith Moyer | OpenVMM |
+| 2026-03-05 | Wu Yongzheng | |
+| 2026-03-19 | Scott Raynor | |
+| 2026-04-02 | Ahmed Magdy | Enarx |
+| 2026-04-16 | Alec Fernandez | Gramine |
+| 2026-04-30 | Fritz Alder | COCONUT-SVSM |
+| 2026-05-14 | Yash Mankad / Ram Pai | Keystone |
+| 2026-05-28 | Bob Blessing-Hartley | SPDM-RS |
+| 2026-06-11 | Mingshen Sun | OE SDK |
+| 2026-06-25 | Nathaniel McCallum | |
+| 2026-07-09 | Rene Kolga / Keith Moyer | Veraison |
+| 2026-07-23 | Wu Yongzheng | Occulum |
+| 2026-08-06 | Scott Raynor | Certifier Framework |
+| 2026-08-20 | Ahmed Magdy | VirTEE |
+| 2026-09-03 | Alec Fernandez | dstack |
+| 2026-09-17 | Fritz Alder | ManaTEE |
+| 2026-10-01 | Yash Mankad / Ram Pai | |
+| 2026-10-15 | Bob Blessing-Hartley | |
+| 2026-10-29 | Mingshen Sun | |
+| 2026-11-12 | Nathaniel McCallum | |
+| 2026-11-26 | Rene Kolga / Keith Moyer | Islet |
+| 2026-12-10 | Wu Yongzheng | |
+| 2026-12-24 | Scott Raynor | |

--- a/TAC/meeting-schedule.md
+++ b/TAC/meeting-schedule.md
@@ -1,0 +1,44 @@
+# TAC Meeting Schedule
+
+The TAC uses a rotating chair model. Each meeting is facilitated by a different TAC member on a fixed rotation. This file is the **source of truth** for the rotation and is read by GitHub Actions to send reminders and prepare meeting artifacts.
+
+## How it works
+
+- The TAC meets on **alternating Thursdays, 8–9 am PT**
+- The chair for each meeting is listed in the schedule below
+- The chair is responsible for: preparing the agenda, sending a reminder to the TAC list, and facilitating the meeting
+- To swap dates with another chair, submit a PR updating this file
+
+## 2026 Meeting Schedule
+
+<!-- The GitHub Action reads this table to determine the current chair and meeting topics. -->
+<!-- Dates must be in YYYY-MM-DD format. -->
+
+| Date | Rotating Chair | CCC Project Topic | TAC Goal Topic | TAC Tech Talk / Proposal / etc |
+|------|---------------|-------------------|----------------|-------------------------------|
+| 2026-01-08 | *no meeting* | | | |
+| 2026-01-22 | Just Dan & Ijlal | Project grant discussion in light of '26 re-budget | Guidance docs | Attested HTTPs Rudiger et al |
+| 2026-02-05 | Nathaniel McCallum | Project grant discussion in light of '26 re-budget | NIST RFI; Blueprints docs | TAC Tech Talk Topic Triage (Fritz) Policy and Attestation (Mike B) |
+| 2026-02-19 | Rene Kolga / Keith Moyer | OpenVMM | NIST RFI; Blueprints docs | TAC Tech Talk Topic Triage (Fritz) |
+| 2026-03-05 | Wu Yongzheng | | NIST RFI; Blueprints docs | |
+| 2026-03-19 | Scott Raynor | | Board meeting download; OC3 Recap; PRs | Blueprints docs; Platform Ownership Endorsements (POE) Scott - Need to reschedule |
+| 2026-04-02 | Ahmed Magdy | Enarx | Finalize Blueprints | Platform Ownership Endorsements (POE) Scott |
+| 2026-04-16 | Alec Fernandez | Gramine | ISO | |
+| 2026-04-30 | Fritz Alder | COCONUT-SVSM | | |
+| 2026-05-14 | Yash Mankad / Ram Pai | Keystone | | |
+| 2026-05-28 | Bob Blessing-Hartley | SPDM-RS | | |
+| 2026-06-11 | Mingshen Sun | OE SDK | | |
+| 2026-06-25 | Nathaniel McCallum | | | |
+| 2026-07-09 | Rene Kolga / Keith Moyer | Veraison | | |
+| 2026-07-23 | Wu Yongzheng | Occulum | | |
+| 2026-08-06 | Scott Raynor | Certifier Framework | | |
+| 2026-08-20 | Ahmed Magdy | VirTEE | | |
+| 2026-09-03 | Alec Fernandez | dstack | | |
+| 2026-09-17 | Fritz Alder | ManaTEE | | |
+| 2026-10-01 | Yash Mankad / Ram Pai | | | |
+| 2026-10-15 | Bob Blessing-Hartley | | | |
+| 2026-10-29 | Mingshen Sun | | | |
+| 2026-11-12 | Nathaniel McCallum | | | |
+| 2026-11-26 | Rene Kolga / Keith Moyer | Islet | | |
+| 2026-12-10 | Wu Yongzheng | | | |
+| 2026-12-24 | Scott Raynor | | | |


### PR DESCRIPTION
Unfortunately I am not aware of how I can test this before merging. So this might be a scenario where we have to merge and I tweak the action in a followup PR.

The goal of this work is to eliminate the manual work we do to notify and prep the rotating chairs. Currently, the process will break if I take a vacation. This PR does a few things:

1. Migrates the TAC meeting schedule from the Google Sheet into TAC/meeting-schedule.md as the new source of truth, preserving all columns: rotating chair, CCC project topic, TAC goal topic, and tech talk/proposal
2. Adds a GitHub Action (tac-chair-reminder.yml) that posts a Slack reminder to #tac every Friday reminding the chair of the meeting on monday.
3. Adds a GitHub Action (tac-meeting-prep.yml) that auto-creates the meeting folder and agenda file via PR each week a meeting is scheduled (this is helpful for me)
4. Adds an agenda template (TAC/Meetings/agenda-template.md) matching the existing minutes format, with placeholders filled automatically by the workflow

Right now I have this posting to #ben-test, once fully tested I can change this to #tac
