### PR TITLE
Added SIG Presentation Schedule

### DIFF
--- a/.github/scripts/parse-schedule.py
+++ b/.github/scripts/parse-schedule.py
@@ -22,16 +22,17 @@ def parse_schedule(path: str = "TAC/meeting-schedule.md") -> list[dict]:
 
     meetings = []
     for line in schedule_section.strip().splitlines():
-        # Match table rows with 3 columns:
-        # | Date | Rotating Chair | CCC Project Topic |
+        # Match table rows with 4 columns:
+        # | Date | Rotating Chair | CCC Project Topic | SIG Annual Review |
         match = re.match(
             r"\|\s*(\d{4}-\d{2}-\d{2})\s*\|"  # Date
             r"\s*(.*?)\s*\|"  # Rotating Chair
-            r"\s*(.*?)\s*\|",  # CCC Project Topic
+            r"\s*(.*?)\s*\|"  # CCC Project Topic
+            r"\s*(.*?)\s*\|",  # SIG Annual Review
             line,
         )
         if match:
-            date_str, chair, project_topic = match.groups()
+            date_str, chair, project_topic, sig_review = match.groups()
 
             # Skip "no meeting" rows
             if "no meeting" in chair.lower():
@@ -47,6 +48,7 @@ def parse_schedule(path: str = "TAC/meeting-schedule.md") -> list[dict]:
                     "date": date_str,
                     "chair": chair,
                     "project_topic": project_topic.strip(),
+                    "sig_review": sig_review.strip(),
                 }
             )
 

--- a/.github/workflows/tac-chair-reminder.yml
+++ b/.github/workflows/tac-chair-reminder.yml
@@ -34,11 +34,13 @@ jobs:
           date=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('date',''))")
           chair=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('chair',''))")
           project_topic=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('project_topic',''))")
+          sig_review=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('sig_review',''))")
           error=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error',''))")
 
           echo "date=$date" >> "$GITHUB_OUTPUT"
           echo "chair=$chair" >> "$GITHUB_OUTPUT"
           echo "project_topic=$project_topic" >> "$GITHUB_OUTPUT"
+          echo "sig_review=$sig_review" >> "$GITHUB_OUTPUT"
           echo "error=$error" >> "$GITHUB_OUTPUT"
 
           if [ -n "$error" ]; then
@@ -59,6 +61,7 @@ jobs:
           MEETING_DATE: ${{ steps.meeting.outputs.date }}
           CHAIR_NAME: ${{ steps.meeting.outputs.chair }}
           PROJECT_TOPIC: ${{ steps.meeting.outputs.project_topic }}
+          SIG_REVIEW: ${{ steps.meeting.outputs.sig_review }}
         run: |
           # Format the date nicely
           formatted_date=$(date -d "$MEETING_DATE" "+%A, %B %-d, %Y" 2>/dev/null || echo "$MEETING_DATE")
@@ -66,7 +69,14 @@ jobs:
           # Build the agenda topics section dynamically
           topics=""
           if [ -n "$PROJECT_TOPIC" ]; then
-            topics="\n\n*Scheduled Topics:*\n• *CCC Project:* ${PROJECT_TOPIC}"
+            topics="${topics}\n• *CCC Project:* ${PROJECT_TOPIC}"
+          fi
+          if [ -n "$SIG_REVIEW" ]; then
+            topics="${topics}\n• *SIG Annual Review:* ${SIG_REVIEW}"
+          fi
+
+          if [ -n "$topics" ]; then
+            topics="\n\n*Scheduled Topics:*${topics}"
           fi
 
           curl -X POST "$SLACK_WEBHOOK_URL" \

--- a/TAC/meeting-schedule.md
+++ b/TAC/meeting-schedule.md
@@ -14,31 +14,31 @@ The TAC uses a rotating chair model. Each meeting is facilitated by a different 
 <!-- The GitHub Action reads this table to determine the current chair and meeting topics. -->
 <!-- Dates must be in YYYY-MM-DD format. -->
 
-| Date | Rotating Chair | CCC Project Topic |
-|------|---------------|-------------------|
-| 2026-01-08 | *no meeting* | |
-| 2026-01-22 | Just Dan & Ijlal | Project grant discussion in light of '26 re-budget |
-| 2026-02-05 | Nathaniel McCallum | Project grant discussion in light of '26 re-budget |
-| 2026-02-19 | Rene Kolga / Keith Moyer | OpenVMM |
-| 2026-03-05 | Wu Yongzheng | |
-| 2026-03-19 | Scott Raynor | |
-| 2026-04-02 | Ahmed Magdy | Enarx |
-| 2026-04-16 | Alec Fernandez | Gramine |
-| 2026-04-30 | Fritz Alder | COCONUT-SVSM |
-| 2026-05-14 | Yash Mankad / Ram Pai | Keystone |
-| 2026-05-28 | Bob Blessing-Hartley | SPDM-RS |
-| 2026-06-11 | Mingshen Sun | OE SDK |
-| 2026-06-25 | Nathaniel McCallum | |
-| 2026-07-09 | Rene Kolga / Keith Moyer | Veraison |
-| 2026-07-23 | Wu Yongzheng | Occulum |
-| 2026-08-06 | Scott Raynor | Certifier Framework |
-| 2026-08-20 | Ahmed Magdy | VirTEE |
-| 2026-09-03 | Alec Fernandez | dstack |
-| 2026-09-17 | Fritz Alder | ManaTEE |
-| 2026-10-01 | Yash Mankad / Ram Pai | |
-| 2026-10-15 | Bob Blessing-Hartley | |
-| 2026-10-29 | Mingshen Sun | |
-| 2026-11-12 | Nathaniel McCallum | |
-| 2026-11-26 | Rene Kolga / Keith Moyer | Islet |
-| 2026-12-10 | Wu Yongzheng | |
-| 2026-12-24 | Scott Raynor | |
+| Date | Rotating Chair | CCC Project Topic | SIG Annual Review |
+|------|---------------|-------------------|-------------------|
+| 2026-01-08 | *no meeting* | | |
+| 2026-01-22 | Just Dan & Ijlal | Project grant discussion in light of '26 re-budget | |
+| 2026-02-05 | Nathaniel McCallum | Project grant discussion in light of '26 re-budget | |
+| 2026-02-19 | Rene Kolga / Keith Moyer | OpenVMM | |
+| 2026-03-05 | Wu Yongzheng | | |
+| 2026-03-19 | Scott Raynor | | |
+| 2026-04-02 | Ahmed Magdy | Enarx | |
+| 2026-04-16 | Alec Fernandez | Gramine | |
+| 2026-04-30 | Fritz Alder | COCONUT-SVSM | |
+| 2026-05-14 | Yash Mankad / Ram Pai | Keystone | |
+| 2026-05-28 | Bob Blessing-Hartley | SPDM-RS | Attestation |
+| 2026-06-11 | Mingshen Sun | OE SDK | |
+| 2026-06-25 | Nathaniel McCallum | | Governance Risk and Compliance |
+| 2026-07-09 | Rene Kolga / Keith Moyer | Veraison | |
+| 2026-07-23 | Wu Yongzheng | Occulum | Kernel |
+| 2026-08-06 | Scott Raynor | Certifier Framework | |
+| 2026-08-20 | Ahmed Magdy | VirTEE | Trustworthy Workload Identity |
+| 2026-09-03 | Alec Fernandez | dstack | |
+| 2026-09-17 | Fritz Alder | ManaTEE | |
+| 2026-10-01 | Yash Mankad / Ram Pai | | |
+| 2026-10-15 | Bob Blessing-Hartley | | |
+| 2026-10-29 | Mingshen Sun | | |
+| 2026-11-12 | Nathaniel McCallum | | |
+| 2026-11-26 | Rene Kolga / Keith Moyer | Islet | |
+| 2026-12-10 | Wu Yongzheng | | |
+| 2026-12-24 | Scott Raynor | | |


### PR DESCRIPTION
1. Added SIG Review Column
2. Started SIG reviews on 2026-05-28,  with one scheduled each month
3. Updated reminders

@dcmiddle feel free to tweak dates, etc. I thought we could just get something on _paper_ and then work with the SIGs on adjustments as needed. 